### PR TITLE
Fix NoClassDefFoundError before Lollipop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 27 00:29:09 EDT 2019
+#Wed Mar 11 15:21:45 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -13,6 +13,9 @@ ext {
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.1'
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -18,6 +18,11 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName radarVersion
+        javaCompileOptions {
+            annotationProcessorOptions {
+                includeCompileClasspath true
+            }
+        }
     }
     buildTypes {
         release {
@@ -36,7 +41,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:17.0.0'
     implementation 'com.google.android.gms:play-services-location:17.0.0'

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationReceiver.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
 import com.google.android.gms.location.LocationResult
@@ -45,13 +46,24 @@ class RadarLocationReceiver : BroadcastReceiver() {
                         Geofence.GEOFENCE_TRANSITION_DWELL -> Radar.RadarLocationSource.GEOFENCE_DWELL
                         else -> Radar.RadarLocationSource.GEOFENCE_EXIT
                     }
-                    RadarJobScheduler.scheduleJob(context, it, source)
+
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        RadarJobScheduler.scheduleJob(context, it, source)
+                    } else {
+                        Radar.handleLocation(context, it, source)
+                    }
                 }
             }
             ACTION_LOCATION -> {
                 val result = LocationResult.extractResult(intent)
                 result?.lastLocation?.also {
-                    RadarJobScheduler.scheduleJob(context, it, Radar.RadarLocationSource.BACKGROUND_LOCATION)
+                    val source = Radar.RadarLocationSource.BACKGROUND_LOCATION
+
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        RadarJobScheduler.scheduleJob(context, it, source)
+                    } else {
+                        Radar.handleLocation(context, it, source)
+                    }
                 }
             }
             Intent.ACTION_BOOT_COMPLETED -> {

--- a/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
@@ -81,6 +81,7 @@ internal object RadarUtils {
         return latitudeValid && longitudeValid && accuracyValid
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     internal fun getUaChannelId(): String? {
         try {
             val urbanAirshipClass = Class.forName("com.urbanairship.UAirship")
@@ -111,6 +112,7 @@ internal object RadarUtils {
         return null
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     internal fun getUaNamedUserId(): String? {
         try {
             val urbanAirshipClass = Class.forName("com.urbanairship.UAirship")
@@ -141,6 +143,7 @@ internal object RadarUtils {
         return null
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     internal fun getUaSessionId(): String? {
         try {
             val urbanAirshipClass = Class.forName("com.urbanairship.UAirship")


### PR DESCRIPTION
`JobScheduler` was added in Lollipop (API level 21): https://developer.android.com/reference/android/app/job/JobScheduler

Because of Doze Mode and because the process may occasionally get killed, we use `JobScheduler` to process geofence transitions and location updates on newer Android versions. `RadarJobScheduler` picks up these jobs and passes the location updates to `Radar.handleLocation()`.

Before passing location updates to `RadarJobScheduler`, we need to check whether we're on Lollipop or later. Pre-Lollipop, we can just pass location updates to `Radar.handleLocation()` immediately.