### PR TITLE
Support string values for enums in RadarTrackingOptions.fromJson()

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 ext {
-    radarVersion = '3.0.5'
+    radarVersion = '3.0.6'
 }
 
 android {

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -108,6 +108,11 @@ data class RadarTrackingOptions(
         NONE(0);
 
         internal companion object {
+            internal const val HIGH_STR = "high"
+            internal const val MEDIUM_STR = "medium"
+            internal const val LOW_STR = "low"
+            internal const val NONE_STR = "none"
+
             fun fromInt(desiredAccuracy: Int?): RadarTrackingOptionsDesiredAccuracy {
                 for (value in values()) {
                     if (desiredAccuracy == value.desiredAccuracy) {
@@ -119,10 +124,10 @@ data class RadarTrackingOptions(
 
             fun fromRadarString(desiredAccuracy: String?): RadarTrackingOptionsDesiredAccuracy {
                 return when(desiredAccuracy) {
-                    "high" -> HIGH
-                    "medium" -> MEDIUM
-                    "low" -> LOW
-                    "none" -> NONE
+                    HIGH_STR -> HIGH
+                    MEDIUM_STR -> MEDIUM
+                    LOW_STR -> LOW
+                    NONE_STR -> NONE
                     else -> MEDIUM
                 }
             }
@@ -130,10 +135,10 @@ data class RadarTrackingOptions(
 
         fun toRadarString(): String {
             return when(this) {
-                HIGH -> "high"
-                MEDIUM -> "medium"
-                LOW -> "low"
-                NONE -> "none"
+                HIGH -> HIGH_STR
+                MEDIUM -> MEDIUM_STR
+                LOW -> LOW_STR
+                NONE -> NONE_STR
             }
         }
     }
@@ -148,6 +153,9 @@ data class RadarTrackingOptions(
         NONE(0);
 
         internal companion object {
+            internal const val STOPS_STR = "stops"
+            internal const val NONE_STR = "none"
+
             fun fromInt(replay: Int?): RadarTrackingOptionsReplay {
                 for (value in values()) {
                     if (replay == value.replay) {
@@ -159,8 +167,8 @@ data class RadarTrackingOptions(
 
             fun fromRadarString(replay: String?): RadarTrackingOptionsReplay {
                 return when(replay) {
-                    "stops" -> STOPS
-                    "none" -> NONE
+                    STOPS_STR -> STOPS
+                    NONE_STR -> NONE
                     else -> NONE
                 }
             }
@@ -168,8 +176,8 @@ data class RadarTrackingOptions(
 
         fun toRadarString(): String {
             return when(this) {
-                STOPS -> "stops"
-                NONE -> "none"
+                STOPS -> STOPS_STR
+                NONE -> NONE_STR
             }
         }
     }
@@ -183,6 +191,10 @@ data class RadarTrackingOptions(
         ALL(2);
 
         internal companion object {
+            internal const val NONE_STR = "none"
+            internal const val STOPS_AND_EXITS_STR = "stopsAndExits"
+            internal const val ALL_STR = "all"
+
             fun fromInt(sync: Int?): RadarTrackingOptionsSync {
                 for (value in values()) {
                     if (sync == value.sync) {
@@ -194,9 +206,9 @@ data class RadarTrackingOptions(
 
             fun fromRadarString(sync: String?): RadarTrackingOptionsSync {
                 return when(sync) {
-                    "all" -> ALL
-                    "stopsAndExits" -> STOPS_AND_EXITS
-                    "none" -> NONE
+                    ALL_STR -> ALL
+                    STOPS_AND_EXITS_STR -> STOPS_AND_EXITS
+                    NONE_STR -> NONE
                     else -> STOPS_AND_EXITS
                 }
             }
@@ -204,9 +216,9 @@ data class RadarTrackingOptions(
 
         fun toRadarString(): String {
             return when(this) {
-                ALL -> "all"
-                STOPS_AND_EXITS -> "stopsAndExits"
-                NONE -> "none"
+                ALL -> ALL_STR
+                STOPS_AND_EXITS -> STOPS_AND_EXITS_STR
+                NONE -> NONE_STR
             }
         }
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -116,6 +116,25 @@ data class RadarTrackingOptions(
                 }
                 return MEDIUM
             }
+
+            fun fromRadarString(desiredAccuracy: String?): RadarTrackingOptionsDesiredAccuracy {
+                return when(desiredAccuracy) {
+                    "high" -> HIGH
+                    "medium" -> MEDIUM
+                    "low" -> LOW
+                    "none" -> NONE
+                    else -> MEDIUM
+                }
+            }
+        }
+
+        fun toRadarString(): String {
+            return when(this) {
+                HIGH -> "high"
+                MEDIUM -> "medium"
+                LOW -> "low"
+                NONE -> "none"
+            }
         }
     }
 
@@ -137,6 +156,21 @@ data class RadarTrackingOptions(
                 }
                 return NONE
             }
+
+            fun fromRadarString(replay: String?): RadarTrackingOptionsReplay {
+                return when(replay) {
+                    "stops" -> STOPS
+                    "none" -> NONE
+                    else -> NONE
+                }
+            }
+        }
+
+        fun toRadarString(): String {
+            return when(this) {
+                STOPS -> "stops"
+                NONE -> "none"
+            }
         }
     }
 
@@ -156,6 +190,23 @@ data class RadarTrackingOptions(
                     }
                 }
                 return STOPS_AND_EXITS
+            }
+
+            fun fromRadarString(sync: String?): RadarTrackingOptionsSync {
+                return when(sync) {
+                    "all" -> ALL
+                    "stopsAndExits" -> STOPS_AND_EXITS
+                    "none" -> NONE
+                    else -> STOPS_AND_EXITS
+                }
+            }
+        }
+
+        fun toRadarString(): String {
+            return when(this) {
+                ALL -> "all"
+                STOPS_AND_EXITS -> "stopsAndExits"
+                NONE -> "none"
             }
         }
     }
@@ -254,19 +305,37 @@ data class RadarTrackingOptions(
 
         @JvmStatic
         fun fromJson(obj: JSONObject): RadarTrackingOptions {
+            val desiredAccuracy = if (obj.has(KEY_DESIRED_ACCURACY) && obj.get(KEY_DESIRED_ACCURACY) is String) {
+                RadarTrackingOptionsDesiredAccuracy.fromRadarString(obj.optString(KEY_DESIRED_ACCURACY))
+            } else {
+                RadarTrackingOptionsDesiredAccuracy.fromInt(obj.optInt(KEY_DESIRED_ACCURACY))
+            }
+
+            val replay = if (obj.has(KEY_REPLAY) && obj.get(KEY_REPLAY) is String) {
+                RadarTrackingOptionsReplay.fromRadarString(obj.optString(KEY_REPLAY))
+            } else {
+                RadarTrackingOptionsReplay.fromInt(obj.optInt(KEY_REPLAY))
+            }
+
+            val sync = if (obj.has(KEY_SYNC) && obj.get(KEY_SYNC) is String) {
+                RadarTrackingOptionsSync.fromRadarString(obj.optString(KEY_SYNC))
+            } else {
+                RadarTrackingOptionsSync.fromInt(obj.optInt(KEY_SYNC))
+            }
+
             return RadarTrackingOptions(
                 desiredStoppedUpdateInterval = obj.optInt(KEY_DESIRED_STOPPED_UPDATE_INTERVAL),
                 fastestStoppedUpdateInterval = obj.optInt(KEY_FASTEST_STOPPED_UPDATE_INTERVAL),
                 desiredMovingUpdateInterval = obj.optInt(KEY_DESIRED_MOVING_UPDATE_INTERVAL),
                 fastestMovingUpdateInterval = obj.optInt(KEY_FASTEST_MOVING_UPDATE_INTERVAL),
                 desiredSyncInterval = obj.optInt(KEY_DESIRED_SYNC_INTERVAL),
-                desiredAccuracy = RadarTrackingOptionsDesiredAccuracy.fromInt(obj.optInt(KEY_DESIRED_ACCURACY)),
+                desiredAccuracy = desiredAccuracy,
                 stopDuration = obj.optInt(KEY_STOP_DURATION),
                 stopDistance = obj.optInt(KEY_STOP_DISTANCE),
                 startTrackingAfter = if (obj.has(KEY_START_TRACKING_AFTER)) Date(obj.optLong(KEY_START_TRACKING_AFTER)) else null,
                 stopTrackingAfter = if (obj.has(KEY_STOP_TRACKING_AFTER)) Date(obj.optLong(KEY_STOP_TRACKING_AFTER)) else null,
-                replay = RadarTrackingOptionsReplay.fromInt(obj.optInt(KEY_REPLAY)),
-                sync = RadarTrackingOptionsSync.fromInt(obj.optInt(KEY_SYNC)),
+                replay = replay,
+                sync = sync,
                 useStoppedGeofence = obj.optBoolean(KEY_USE_STOPPED_GEOFENCE),
                 stoppedGeofenceRadius = obj.optInt(KEY_STOPPED_GEOFENCE_RADIUS, 200),
                 useMovingGeofence = obj.optBoolean(KEY_USE_MOVING_GEOFENCE),
@@ -283,13 +352,13 @@ data class RadarTrackingOptions(
         obj.put(KEY_DESIRED_MOVING_UPDATE_INTERVAL, desiredMovingUpdateInterval)
         obj.put(KEY_FASTEST_MOVING_UPDATE_INTERVAL, fastestMovingUpdateInterval)
         obj.put(KEY_DESIRED_SYNC_INTERVAL, desiredSyncInterval)
-        obj.put(KEY_DESIRED_ACCURACY, desiredAccuracy.desiredAccuracy)
+        obj.put(KEY_DESIRED_ACCURACY, desiredAccuracy.toRadarString())
         obj.put(KEY_STOP_DURATION, stopDuration)
         obj.put(KEY_STOP_DISTANCE, stopDistance)
         obj.put(KEY_START_TRACKING_AFTER, startTrackingAfter?.time)
         obj.put(KEY_STOP_TRACKING_AFTER, stopTrackingAfter?.time)
-        obj.put(KEY_REPLAY, replay.replay)
-        obj.put(KEY_SYNC, sync.sync)
+        obj.put(KEY_REPLAY, replay.toRadarString())
+        obj.put(KEY_SYNC, sync.toRadarString())
         obj.put(KEY_USE_STOPPED_GEOFENCE, useStoppedGeofence)
         obj.put(KEY_STOPPED_GEOFENCE_RADIUS, stoppedGeofenceRadius)
         obj.put(KEY_USE_MOVING_GEOFENCE, useMovingGeofence)

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -539,7 +539,7 @@ class RadarTest {
     }
 
     @Test
-    fun test_Radar_startTracking_custom_json() {
+    fun test_Radar_startTracking_custom_enum_int() {
         permissionsHelperMock.mockFineLocationPermissionGranted = true
 
         Radar.stopTracking()
@@ -547,8 +547,26 @@ class RadarTest {
         val options = RadarTrackingOptions.CONTINUOUS
         options.desiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW
         val json = options.toJson()
-        json.put("desiredAccuracy", RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW.desiredAccuracy)
+        json.put("desiredAccuracy", 1)
         val newOptions = RadarTrackingOptions.fromJson(json)
+        Radar.startTracking(newOptions)
+        assertEquals(newOptions, Radar.getTrackingOptions())
+        assertEquals(newOptions, options)
+        assertTrue(Radar.isTracking())
+    }
+
+    @Test
+    fun test_Radar_startTracking_custom_enum_string() {
+        permissionsHelperMock.mockFineLocationPermissionGranted = true
+
+        Radar.stopTracking()
+
+        val options = RadarTrackingOptions.CONTINUOUS
+        options.desiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW
+        val json = options.toJson()
+        json.put("desiredAccuracy", "low")
+        val newOptions = RadarTrackingOptions.fromJson(json)
+        Radar.startTracking(newOptions)
         assertEquals(newOptions, Radar.getTrackingOptions())
         assertEquals(newOptions, options)
         assertTrue(Radar.isTracking())

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -546,8 +546,8 @@ class RadarTest {
 
         val options = RadarTrackingOptions.CONTINUOUS
         options.desiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW
-        options.replay = RadarTrackingOptions.RadarTrackingOptionsReplay.NONE
-        options.sync = RadarTrackingOptions.RadarTrackingOptionsSync.ALL
+        options.replay = RadarTrackingOptions.RadarTrackingOptionsReplay.STOPS
+        options.sync = RadarTrackingOptions.RadarTrackingOptionsSync.NONE
         val json = options.toJson()
         json.put("desiredAccuracy", 1)
         json.put("replay", 1)
@@ -567,8 +567,8 @@ class RadarTest {
 
         val options = RadarTrackingOptions.CONTINUOUS
         options.desiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW
-        options.replay = RadarTrackingOptions.RadarTrackingOptionsReplay.NONE
-        options.sync = RadarTrackingOptions.RadarTrackingOptionsSync.STOPS_AND_EXITS
+        options.replay = RadarTrackingOptions.RadarTrackingOptionsReplay.STOPS
+        options.sync = RadarTrackingOptions.RadarTrackingOptionsSync.NONE
         val json = options.toJson()
         json.put("desiredAccuracy", "low")
         json.put("replay", "stops")

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -539,6 +539,22 @@ class RadarTest {
     }
 
     @Test
+    fun test_Radar_startTracking_custom_json() {
+        permissionsHelperMock.mockFineLocationPermissionGranted = true
+
+        Radar.stopTracking()
+
+        val options = RadarTrackingOptions.CONTINUOUS
+        options.desiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW
+        val json = options.toJson()
+        json.put("desiredAccuracy", RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW.desiredAccuracy)
+        val newOptions = RadarTrackingOptions.fromJson(json)
+        assertEquals(newOptions, Radar.getTrackingOptions())
+        assertEquals(newOptions, options)
+        assertTrue(Radar.isTracking())
+    }
+
+    @Test
     fun test_Radar_stopTracking() {
         Radar.stopTracking()
         assertFalse(Radar.isTracking())

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -546,8 +546,12 @@ class RadarTest {
 
         val options = RadarTrackingOptions.CONTINUOUS
         options.desiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW
+        options.replay = RadarTrackingOptions.RadarTrackingOptionsReplay.NONE
+        options.sync = RadarTrackingOptions.RadarTrackingOptionsSync.ALL
         val json = options.toJson()
         json.put("desiredAccuracy", 1)
+        json.put("replay", 1)
+        json.put("sync", 0)
         val newOptions = RadarTrackingOptions.fromJson(json)
         Radar.startTracking(newOptions)
         assertEquals(newOptions, Radar.getTrackingOptions())
@@ -563,8 +567,12 @@ class RadarTest {
 
         val options = RadarTrackingOptions.CONTINUOUS
         options.desiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.LOW
+        options.replay = RadarTrackingOptions.RadarTrackingOptionsReplay.NONE
+        options.sync = RadarTrackingOptions.RadarTrackingOptionsSync.STOPS_AND_EXITS
         val json = options.toJson()
         json.put("desiredAccuracy", "low")
+        json.put("replay", "stops")
+        json.put("sync", "none")
         val newOptions = RadarTrackingOptions.fromJson(json)
         Radar.startTracking(newOptions)
         assertEquals(newOptions, Radar.getTrackingOptions())


### PR DESCRIPTION
iOS stores tracking option enum values as strings, whereas Android stores them as ints. This PR changes the Android SDK to store them as strings, while keeping backcompat.

In the JavaScript wrappers, this supports things like:

```
cordova.plugins.radar.startTrackingCustom({
  desiredAccuracy: 'high',
  sync: 'all',
  replay: 'none'
});