### PR TITLE
Send locationAuthorization to GET /config

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -289,7 +289,7 @@ object Radar {
 
     private var initialized = false
     private lateinit var context: Context
-    private lateinit var logger: RadarLogger
+    internal lateinit var logger: RadarLogger
     internal lateinit var apiClient: RadarApiClient
     internal lateinit var locationManager: RadarLocationManager
 
@@ -308,13 +308,16 @@ object Radar {
         initialized = true
         this.context = context.applicationContext
 
+        if (!this::logger.isInitialized) {
+            this.logger = RadarLogger()
+        }
+
+        RadarSettings.updateSessionId(this.context)
+
         if (publishableKey != null) {
             RadarSettings.setPublishableKey(this.context, publishableKey)
         }
 
-        if (!this::logger.isInitialized) {
-            this.logger = RadarLogger()
-        }
         if (!this::apiClient.isInitialized) {
             this.apiClient = RadarApiClient(this.context)
         }

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -14,6 +14,12 @@ internal class RadarActivityLifecycleCallbacks : Application.ActivityLifecycleCa
     }
 
     override fun onActivityResumed(activity: Activity) {
+        if (count == 0) {
+            val updated = RadarSettings.updateSessionId(activity.applicationContext)
+            if (updated) {
+                Radar.apiClient.getConfig()
+            }
+        }
         count++
         foreground = count > 0
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -68,14 +68,7 @@ internal class RadarApiClient(
 
         val queryParams = StringBuilder()
         queryParams.append("installId=${RadarSettings.getInstallId(context)}")
-        val userId = RadarSettings.getUserId(context)
-        if (userId != null) {
-            queryParams.append("&userId=$userId")
-        }
-        val deviceId = RadarUtils.getDeviceId(context)
-        if (deviceId != null) {
-            queryParams.append("&deviceId=$deviceId")
-        }
+        queryParams.append("&locationAuthorization=${RadarUtils.getLocationAuthorization(context)}")
 
         val host = RadarSettings.getHost(context)
         val uri = Uri.parse(host).buildUpon()

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -68,6 +68,7 @@ internal class RadarApiClient(
 
         val queryParams = StringBuilder()
         queryParams.append("installId=${RadarSettings.getInstallId(context)}")
+        queryParams.append("&sessionId=${RadarSettings.getSessionId(context)}")
         queryParams.append("&locationAuthorization=${RadarUtils.getLocationAuthorization(context)}")
 
         val host = RadarSettings.getHost(context)

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -10,6 +10,7 @@ internal object RadarSettings {
 
     private const val KEY_PUBLISHABLE_KEY = "publishable_key"
     private const val KEY_INSTALL_ID = "install_id"
+    private const val KEY_SESSION_ID = "session_id"
     private const val KEY_ID = "radar_user_id"
     private const val KEY_USER_ID = "user_id"
     private const val KEY_DESCRIPTION = "user_description"
@@ -46,6 +47,23 @@ internal object RadarSettings {
             getSharedPreferences(context).edit { putString(KEY_INSTALL_ID, installId) }
         }
         return installId
+    }
+
+    internal fun getSessionId(context: Context): String {
+        return "%.0f".format(getSharedPreferences(context).getLong(KEY_SESSION_ID, 0))
+    }
+
+    internal fun updateSessionId(context: Context): Boolean {
+        val timestampSeconds = System.currentTimeMillis() / 1000
+        val sessionIdSeconds = getSharedPreferences(context).getLong(KEY_SESSION_ID, 0)
+        if (timestampSeconds - sessionIdSeconds > 300) {
+            getSharedPreferences(context).edit { putLong(KEY_SESSION_ID, sessionIdSeconds) }
+
+            Radar.logger.i(context, "New session | sessionId = ${this.getSessionId(context)}")
+
+            return true
+        }
+        return false
     }
 
     internal fun getId(context: Context): String? {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import org.json.JSONObject
+import java.text.DecimalFormat
 import java.util.UUID
 
 internal object RadarSettings {
@@ -50,7 +51,7 @@ internal object RadarSettings {
     }
 
     internal fun getSessionId(context: Context): String {
-        return "%.0f".format(getSharedPreferences(context).getLong(KEY_SESSION_ID, 0))
+        return DecimalFormat("#").format(getSharedPreferences(context).getLong(KEY_SESSION_ID, 0))
     }
 
     internal fun updateSessionId(context: Context): Boolean {

--- a/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
@@ -1,12 +1,16 @@
 package io.radar.sdk
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
 import android.os.Build
 import android.provider.Settings
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
 import java.util.Calendar
@@ -68,6 +72,18 @@ internal object RadarUtils {
     internal const val deviceType = "Android"
 
     internal val deviceMake =  Build.MANUFACTURER
+
+    internal fun getLocationAuthorization(context: Context): String {
+        var locationAuthorization = "DENIED"
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            locationAuthorization = "GRANTED_FOREGROUND"
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            locationAuthorization = "GRANTED_BACKGROUND"
+        }
+        return locationAuthorization
+    }
 
     internal fun getLocationEnabled(context: Context): Boolean {
         val manager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -656,8 +656,14 @@ class RadarTest {
     }
 
     @Test
-    fun test_Radar_stopTrip() {
-        Radar.stopTrip()
+    fun test_Radar_completeTrip() {
+        Radar.completeTrip()
+        assertNull(Radar.getTripOptions())
+    }
+
+    @Test
+    fun test_Radar_cancelTrip() {
+        Radar.cancelTrip()
         assertNull(Radar.getTripOptions())
     }
 


### PR DESCRIPTION
Sends `locationAuthorization` (`DENIED`, `GRANTED_FOREGROUND`, `GRANTED_BACKGROUND`) to `GET /config`.

Adds a `sessionId`, updated when the app is opened or foregrounded (with 5 minute timeout), also sent to `GET /config`.