### PR TITLE
Move BluetoothAdapter initialization after permission check

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 ext {
-    radarVersion = '3.1.1'
+    radarVersion = '3.1.2'
 }
 
 android {

--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
@@ -26,7 +26,7 @@ internal class RadarBeaconManager(
     internal var permissionsHelper: RadarPermissionsHelper = RadarPermissionsHelper()
 ) {
 
-    private val adapter = BluetoothAdapter.getDefaultAdapter()
+    private lateinit var adapter: BluetoothAdapter
     private var started = false
     private val callbacks = Collections.synchronizedList(mutableListOf<RadarBeaconCallback>())
     private var nearbyBeaconIdentifiers = mutableSetOf<String>()
@@ -72,6 +72,10 @@ internal class RadarBeaconManager(
             callback?.onComplete(RadarStatus.ERROR_PERMISSIONS)
 
             return
+        }
+
+        if (!this::adapter.isInitialized) {
+            adapter = BluetoothAdapter.getDefaultAdapter()
         }
 
         if (!adapter.isEnabled) {

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -84,8 +84,6 @@ internal class RadarLocationManager(
     }
 
     fun getLocation(desiredAccuracy: RadarTrackingOptionsDesiredAccuracy, callback: RadarLocationCallback?) {
-        this.addCallback(callback)
-
         if (!permissionsHelper.fineLocationPermissionGranted(context)) {
             Radar.broadcastErrorIntent(RadarStatus.ERROR_PERMISSIONS)
 
@@ -93,6 +91,8 @@ internal class RadarLocationManager(
 
             return
         }
+
+        this.addCallback(callback)
 
         val locationManager = this
 


### PR DESCRIPTION
- Move `BluetoothAdapter` initialization after permission check
- Prevent extra `getContext()` and `trackOnce()` callback when permissions aren't granted (see #105)