### PR TITLE
Bug fix when calling trackOnce when there are no nearby beacons

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
@@ -95,6 +95,8 @@ internal class RadarBeaconManager(
         if (beacons.isEmpty()) {
             logger.d(this.context, "No beacons to range")
 
+            callback?.onComplete(RadarStatus.ERROR_UNKNOWN)
+
             return
         }
 


### PR DESCRIPTION
```trackOnce``` fails to record a user's location when the ```searchBeacons``` network call comes back with 0 nearby beacons. ```callTrackApi``` is never called because ```rangeBeacons``` doesn't call a callback method when the condition ```beacons.isEmpty()``` is met. 