### PR TITLE
Add detekt and jacoco configurations:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
-version: 2.1
+version: 2
 jobs:
   build_and_test:
-    working_directory: ~/sdk
     docker:
       - image: circleci/android:api-30
     steps:
@@ -11,8 +10,23 @@ jobs:
           command: yes | sdkmanager --licenses || true
       - run:
           name: Build
-          command: ./gradlew check build assembleAndroidTest --stacktrace
+          command: ./gradlew check
+      # JUnit Test Results
+      - store_test_results:
+          path: sdk/build/test-results/testDebugUnitTest/TEST-io.radar.sdk.RadarTest.xml
+      # Jacoco Coverage Report
+      - store_artifacts:
+          path: sdk/build/reports/jacoco/jacocoTestReport/html
+          destination: jacoco
+      # Lint Static Analysis Report
+      - store_artifacts:
+          path: sdk/build/reports/lint-results.html
+      # Detekt Static Analysis Report
+      - store_artifacts:
+          path: sdk/build/reports/detekt/debug.html
+          destination: detekt-results.html
 workflows:
+  version: 2
   build_and_test:
     jobs:
       - build_and_test

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 */build
 /captures
 .externalNativeBuild
-/buildSrc/build
+**/jacoco.exec

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,19 @@
 buildscript {
-    ext.kotlin_version = "1.5.21"
+    ext {
+        kotlin_version = '1.6.10'
+        detekt_version = '1.18.1'
+        jacoco_version = '0.8.7'
+
+        radarVersion = '3.3.3'
+    }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath 'com.android.tools.build:gradle:7.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.32"
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.32'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -3,14 +3,13 @@ import io.radar.ci.GitHubClient
 import io.radar.ci.SnapshotDispatcher
 import io.radar.mvnpublish.MavenServer
 
-apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
-apply plugin: "kotlin-android-extensions"
-apply plugin: "org.jetbrains.dokka"
-apply plugin: 'io.radar.mvnpublish'
-
-ext {
-    radarVersion = '3.3.3'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
+    id 'io.radar.mvnpublish'
+    id 'jacoco'
+    id 'io.gitlab.arturbosch.detekt' version "$detekt_version"
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"
@@ -24,7 +23,7 @@ if (githubRelease) {
     } else {
         buildNumber = ''
         // Use the tag from the release name as the version-to-publish / include in source code
-        ext.radarVersion = githubRelease.tag
+        rootProject.ext.radarVersion = githubRelease.tag
     }
 }
 
@@ -36,18 +35,21 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = '1.8'
     }
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 31
-        buildConfigField "String", "VERSION_NAME", "\"$radarVersion\""
+        buildConfigField 'String', 'VERSION_NAME', "\"$radarVersion\""
         multiDexEnabled = true
     }
     buildTypes {
         release {
+            // Disable Proguard
             minifyEnabled false
-            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+        }
+        debug {
+            testCoverageEnabled true
         }
     }
     testOptions {
@@ -56,20 +58,88 @@ android {
         }
     }
     lintOptions {
+        abortOnError false//TODO do not allow failures
         warningsAsErrors true
     }
 }
 
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
+    testLogging {
+        showStandardStreams = true
+        events = ['passed', 'failed', 'skipped']
+    }
+}
+
+tasks.whenTaskAdded {
+    if (it.name == 'testReleaseUnitTest') {
+        it.enabled = false
+    }
+}
+
+detekt {
+    toolVersion = "$detekt_version"
+    ignoreFailures = true//TODO do not allow failures
+    config = rootProject.files('tools/detekt/radar-detekt-config.yml')
+    buildUponDefaultConfig = true
+    reports {
+        html.enabled = true
+        xml.enabled = false
+        txt.enabled = false
+        sarif.enabled = false
+    }
+}
+
+jacoco {
+    toolVersion = "$jacoco_version"
+}
+
+//See https://youtrack.jetbrains.com/issue/KT-44757
+configurations.all {
+    resolutionStrategy {
+        eachDependency { details ->
+            if ('org.jacoco' == details.requested.group) {
+                details.useVersion "$jacoco_version"
+            }
+        }
+    }
+}
+
+task jacocoTestReport(
+        type: JacocoReport,
+        dependsOn: ['testDebugUnitTest', 'createDebugAndroidTestCoverageReport']) {
+
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+
+    FileTree debugTree = fileTree "$buildDir/tmp/kotlin-classes/debug"
+    String mainSrc = "$projectDir/src/main/java"
+
+    sourceDirectories.setFrom mainSrc
+    classDirectories.setFrom debugTree
+    executionData.setFrom fileTree(
+            dir: "$buildDir",
+            includes: ['outputs/code_coverage/debugAndroidTest/connected/*coverage.ec',
+                       'outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec']
+    )
+}
+
+check {
+    finalizedBy tasks.jacocoTestReport
+}
+
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.appcompat:appcompat:1.4.0"
-    implementation "androidx.core:core-ktx:1.7.0"
-    implementation "com.google.android.gms:play-services-ads-identifier:17.1.0"
-    implementation "com.google.android.gms:play-services-location:18.0.0"
-    testImplementation "androidx.test.ext:junit:1.1.3"
-    testImplementation "org.robolectric:robolectric:4.5.1"
+    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'com.google.android.gms:play-services-ads-identifier:17.1.0'
+    implementation 'com.google.android.gms:play-services-location:18.0.0'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation 'org.robolectric:robolectric:4.5.1'
 }
 
 task androidSourcesJar(type: Jar) {
@@ -82,7 +152,7 @@ dokkaHtml.configure {
     outputDirectory.set(file("$rootDir/docs"))
 
     dokkaSourceSets {
-        named("main") {
+        named('main') {
             noAndroidSdkLink.set(false)
         }
     }
@@ -94,7 +164,7 @@ dokkaJavadoc.configure {
 
 task androidJavadocsJar(type: Jar, dependsOn: dokkaJavadoc) {
     group 'publishing'
-    archiveClassifier.set("javadoc")
+    archiveClassifier.set('javadoc')
     from dokkaJavadoc.outputDirectory
 }
 

--- a/tools/detekt/radar-detekt-config.yml
+++ b/tools/detekt/radar-detekt-config.yml
@@ -1,0 +1,12 @@
+# Override default settings. See https://github.com/detekt/detekt/blob/main/detekt-core/src/main/resources/default-detekt-config.yml
+
+style:
+  NewLineAtEndOfFile:
+    active: false
+  MagicNumber:
+    active: false
+exceptions:
+  SwallowedException:
+    active: false
+  TooGenericExceptionCaught:
+    active: false


### PR DESCRIPTION
* detekt is used for Kotlin Static Analysis
* jacoco is used for JVM Unit Test Coverage Analysis

This change is the first of several smaller, incremental PRs to simplify review of the changes in #184 