### PR TITLE
Foreground service fixes

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.3.4'
+    radarVersion = '3.4.0'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.4.0'
+    radarVersion = '3.4.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true" />
         <service android:name=".RadarForegroundService"
-            android:foregroundServiceType="location"
-            android:stopWithTask="true" />
+            android:foregroundServiceType="location" />
     </application>
 </manifest>

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -51,7 +51,7 @@ class RadarForegroundService : Service() {
                 .putExtra(KEY_FOREGROUND_SERVICE_IMPORTANCE, foregroundService.importance ?: NotificationManager.IMPORTANCE_DEFAULT)
                 .putExtra(KEY_FOREGROUND_SERVICE_TITLE, foregroundService.title)
                 .putExtra(KEY_FOREGROUND_SERVICE_TEXT, foregroundService.text)
-                .putExtra(KEY_FOREGROUND_SERVICE_ICON, foregroundService.icon )
+                .putExtra(KEY_FOREGROUND_SERVICE_ICON, foregroundService.icon)
                 .putExtra(KEY_FOREGROUND_SERVICE_ACTIVITY, foregroundService.activity)
                 .putExtra(KEY_FOREGROUND_SERVICE_CHANNEL_NAME, foregroundService.channelName)
             context.applicationContext.startForegroundService(intent)
@@ -89,10 +89,8 @@ class RadarForegroundService : Service() {
         started = true
         val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         manager.deleteNotificationChannel(RADAR_CHANNEL)
-        var id = extras?.getInt(KEY_FOREGROUND_SERVICE_ID) ?: 0
-        id = if (id == 0) NOTIFICATION_ID else id
-        var importance = extras?.getInt(KEY_FOREGROUND_SERVICE_IMPORTANCE) ?: 0
-        importance = if (importance == 0) NotificationManager.IMPORTANCE_DEFAULT else importance
+        val id = extras?.getInt(KEY_FOREGROUND_SERVICE_ID) ?: NOTIFICATION_ID
+        val importance = extras?.getInt(KEY_FOREGROUND_SERVICE_IMPORTANCE) ?: NotificationManager.IMPORTANCE_DEFAULT
         val title = extras?.getString(KEY_FOREGROUND_SERVICE_TITLE)
         val text = extras?.getString(KEY_FOREGROUND_SERVICE_TEXT) ?: "Location tracking started"
         var icon = extras?.getInt(KEY_FOREGROUND_SERVICE_ICON) ?: 0

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -134,4 +134,9 @@ class RadarForegroundService : Service() {
         super.onDestroy()
         started = false
     }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        Radar.locationManager.handleTaskRemoved()
+    }
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -135,8 +135,4 @@ class RadarForegroundService : Service() {
         started = false
     }
 
-    override fun onTaskRemoved(rootIntent: Intent?) {
-        super.onTaskRemoved(rootIntent)
-        Radar.locationManager.handleTaskRemoved()
-    }
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -98,7 +98,7 @@ class RadarForegroundService : Service() {
         var icon = extras?.getInt(KEY_FOREGROUND_SERVICE_ICON) ?: 0
         icon = if (icon == 0) this.applicationInfo.icon else icon
         val smallIcon = resources.getIdentifier(icon.toString(), "drawable", applicationContext.packageName)
-        val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: "Location Tracking"
+        val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: "Location Services"
         val channel = NotificationChannel(RADAR_CHANNEL, channelName, importance)
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -98,7 +98,7 @@ class RadarForegroundService : Service() {
         var icon = extras?.getInt(KEY_FOREGROUND_SERVICE_ICON) ?: 0
         icon = if (icon == 0) this.applicationInfo.icon else icon
         val smallIcon = resources.getIdentifier(icon.toString(), "drawable", applicationContext.packageName)
-        val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: RADAR_CHANNEL
+        val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: "Location Tracking"
         val channel = NotificationChannel(RADAR_CHANNEL, channelName, importance)
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -1,9 +1,7 @@
 package io.radar.sdk
 
 import android.annotation.SuppressLint
-import android.app.NotificationManager
 import android.content.Context
-import android.content.Intent
 import android.location.Location
 import android.os.Build
 import com.google.android.gms.location.*
@@ -171,7 +169,15 @@ internal class RadarLocationManager(
 
     internal fun handleBootCompleted() {
         logger.d("Handling boot completed")
+        wakeUp()
+    }
 
+    internal fun handleTaskRemoved() {
+        logger.d("Handling task removed")
+        wakeUp()
+    }
+
+    private fun wakeUp() {
         this.started = false
         RadarState.setStopped(context, false)
 

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -169,15 +169,7 @@ internal class RadarLocationManager(
 
     internal fun handleBootCompleted() {
         logger.d("Handling boot completed")
-        wakeUp()
-    }
 
-    internal fun handleTaskRemoved() {
-        logger.d("Handling task removed")
-        wakeUp()
-    }
-
-    private fun wakeUp() {
         this.started = false
         RadarState.setStopped(context, false)
 

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -277,7 +277,13 @@ data class RadarTrackingOptions(
         /**
          * Determines the id of the notification. Optional, defaults to `20160525`.
          */
-        val id: Int? = null
+        val id: Int? = null,
+
+        /**
+         * Determines the user-facing channel name, which can be viewed in notification settings for the application.
+         * Optional, defaults to "RadarSDK".
+         */
+        val channelName: String? = null
     ) {
 
         companion object {
@@ -288,6 +294,7 @@ data class RadarTrackingOptions(
             internal const val KEY_FOREGROUND_SERVICE_ACTIVITY = "activity"
             internal const val KEY_FOREGROUND_SERVICE_IMPORTANCE = "importance"
             internal const val KEY_FOREGROUND_SERVICE_ID = "id"
+            internal const val KEY_FOREGROUND_SERVICE_CHANNEL_NAME = "channelName"
 
             @JvmStatic
             fun fromJson(obj: JSONObject?): RadarTrackingOptionsForegroundService? {
@@ -302,8 +309,9 @@ data class RadarTrackingOptions(
                 val activity = if (obj.isNull(KEY_FOREGROUND_SERVICE_ACTIVITY)) null else obj.optString(KEY_FOREGROUND_SERVICE_ACTIVITY)
                 val importance = if (obj.isNull(KEY_FOREGROUND_SERVICE_IMPORTANCE)) null else obj.optInt(KEY_FOREGROUND_SERVICE_IMPORTANCE)
                 val id = if (obj.isNull(KEY_FOREGROUND_SERVICE_ID)) null else obj.optInt(KEY_FOREGROUND_SERVICE_ID)
+                val channelName = if (obj.isNull(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)) null else obj.optString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)
 
-                return RadarTrackingOptionsForegroundService(text, title, icon, updatesOnly, activity, importance, id)
+                return RadarTrackingOptionsForegroundService(text, title, icon, updatesOnly, activity, importance, id, channelName)
             }
         }
 
@@ -317,6 +325,7 @@ data class RadarTrackingOptions(
             obj.put(KEY_FOREGROUND_SERVICE_UPDATES_ONLY, updatesOnly)
             obj.put(KEY_FOREGROUND_SERVICE_IMPORTANCE, importance)
             obj.put(KEY_FOREGROUND_SERVICE_ID, id)
+            obj.put(KEY_FOREGROUND_SERVICE_CHANNEL_NAME, channelName)
             return obj
         }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -281,7 +281,7 @@ data class RadarTrackingOptions(
 
         /**
          * Determines the user-facing channel name, which can be viewed in notification settings for the application.
-         * Optional, defaults to "RadarSDK".
+         * Optional, defaults to `"Location Tracking"`.
          */
         val channelName: String? = null
     ) {

--- a/sdk/src/test/java/io/radar/sdk/RadarTrackingOptionsTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTrackingOptionsTest.kt
@@ -1,0 +1,17 @@
+package io.radar.sdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class RadarTrackingOptionsTest {
+
+    @Test
+    fun testEquals() {
+        assertEquals(RadarTrackingOptions.EFFICIENT, RadarTrackingOptions.fromJson(RadarTrackingOptions.EFFICIENT.toJson()))
+        assertEquals(RadarTrackingOptions.RESPONSIVE, RadarTrackingOptions.fromJson(RadarTrackingOptions.RESPONSIVE.toJson()))
+        assertEquals(RadarTrackingOptions.CONTINUOUS, RadarTrackingOptions.fromJson(RadarTrackingOptions.CONTINUOUS.toJson()))
+    }
+}


### PR DESCRIPTION
Various fixes for the Foreground Service:
1. Add missing default RadarTrackingOptionsForegroundService usage. This allows a default notification to show, even when not customized by the app.
2. Cleanup usages of RadarForegroundService.started, such that it can only be set within the RadarForegroundService class. This helps preserve the single source of truth principal.
3. Remove the bond between the RadarForegroundService and the Activity Lifecycle. This ensures the app can continue tracking in CONTINUOUS mode even if the app activity is killed (or swiped).