### PR TITLE
Small updates to FG Service

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.4.0'
+    radarVersion = '3.4.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true" />
         <service android:name=".RadarForegroundService"
-            android:foregroundServiceType="location"
-            android:stopWithTask="true" />
+            android:foregroundServiceType="location" />
     </application>
 </manifest>

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import androidx.annotation.RequiresApi
+import io.radar.sdk.RadarTrackingOptions.RadarTrackingOptionsForegroundService.Companion.KEY_FOREGROUND_SERVICE_CHANNEL_NAME
 
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -56,7 +57,8 @@ class RadarForegroundService : Service() {
         var icon = extras?.getInt("icon") ?: 0
         icon = if (icon == 0) this.applicationInfo.icon else icon
         val smallIcon = resources.getIdentifier(icon.toString(), "drawable", applicationContext.packageName)
-        val channel = NotificationChannel("RadarSDK", "RadarSDK", importance)
+        val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: "Location Services"
+        val channel = NotificationChannel("RadarSDK", channelName, importance)
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
         var builder = Notification.Builder(applicationContext, "RadarSDK")

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -202,8 +202,9 @@ internal class RadarLocationManager(
         }
 
         if (tracking) {
-            val foregroundService = RadarSettings.getForegroundService(context)
-            if (foregroundService != null && options.foregroundServiceEnabled) {
+            if (options.foregroundServiceEnabled) {
+                val foregroundService = RadarSettings.getForegroundService(context)
+                    ?: RadarTrackingOptions.RadarTrackingOptionsForegroundService()
                 if (!foregroundService.updatesOnly) {
                     this.startForegroundService(foregroundService)
                 }

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -281,7 +281,7 @@ data class RadarTrackingOptions(
 
         /**
          * Determines the user-facing channel name, which can be viewed in notification settings for the application.
-         * Optional, defaults to `"Location Tracking"`.
+         * Optional, defaults to `"Location Services"`.
          */
         val channelName: String? = null
     ) {

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -277,7 +277,13 @@ data class RadarTrackingOptions(
         /**
          * Determines the id of the notification. Optional, defaults to `20160525`.
          */
-        val id: Int? = null
+        val id: Int? = null,
+
+        /**
+         * Determines the user-facing channel name, which can be viewed in notification settings for the application.
+         * Optional, defaults to `"Location Tracking"`.
+         */
+        val channelName: String? = null
     ) {
 
         companion object {
@@ -288,6 +294,7 @@ data class RadarTrackingOptions(
             internal const val KEY_FOREGROUND_SERVICE_ACTIVITY = "activity"
             internal const val KEY_FOREGROUND_SERVICE_IMPORTANCE = "importance"
             internal const val KEY_FOREGROUND_SERVICE_ID = "id"
+            internal const val KEY_FOREGROUND_SERVICE_CHANNEL_NAME = "channelName"
 
             @JvmStatic
             fun fromJson(obj: JSONObject?): RadarTrackingOptionsForegroundService? {
@@ -302,8 +309,9 @@ data class RadarTrackingOptions(
                 val activity = if (obj.isNull(KEY_FOREGROUND_SERVICE_ACTIVITY)) null else obj.optString(KEY_FOREGROUND_SERVICE_ACTIVITY)
                 val importance = if (obj.isNull(KEY_FOREGROUND_SERVICE_IMPORTANCE)) null else obj.optInt(KEY_FOREGROUND_SERVICE_IMPORTANCE)
                 val id = if (obj.isNull(KEY_FOREGROUND_SERVICE_ID)) null else obj.optInt(KEY_FOREGROUND_SERVICE_ID)
+                val channelName = if (obj.isNull(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)) null else obj.optString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)
 
-                return RadarTrackingOptionsForegroundService(text, title, icon, updatesOnly, activity, importance, id)
+                return RadarTrackingOptionsForegroundService(text, title, icon, updatesOnly, activity, importance, id, channelName)
             }
         }
 
@@ -317,6 +325,7 @@ data class RadarTrackingOptions(
             obj.put(KEY_FOREGROUND_SERVICE_UPDATES_ONLY, updatesOnly)
             obj.put(KEY_FOREGROUND_SERVICE_IMPORTANCE, importance)
             obj.put(KEY_FOREGROUND_SERVICE_ID, id)
+            obj.put(KEY_FOREGROUND_SERVICE_CHANNEL_NAME, channelName)
             return obj
         }
 


### PR DESCRIPTION
1. Add missing default RadarTrackingOptionsForegroundService usage. This allows a default notification to show, even when not customized by the app.
2. Remove the bond between the RadarForegroundService and the Activity Lifecycle. This ensures the app can continue tracking in CONTINUOUS mode even if the app activity is killed (or swiped).
3. Add channel customization and change the default name. This ensures all apps that use this SDK do not see "RadarSDK" as a user-facing String in Android's notification settings (see discussion and screenshots on slack).