### PR TITLE
Make sure Radar.initialize is called before any Radar members are called

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.4.1'
+    radarVersion = '3.4.2'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
@@ -145,7 +145,6 @@ internal class RadarBeaconManager(
         } catch (e: SecurityException) {
             logger.e("Error starting monitoring beacons", e)
         }
-        
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
@@ -130,17 +130,22 @@ internal class RadarBeaconManager(
             return
         }
 
-        val scanSettings = ScanSettings.Builder()
-            .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
-            .setCallbackType(ScanSettings.CALLBACK_TYPE_FIRST_MATCH)
-            .setReportDelay(30000)
-            .setMatchMode(ScanSettings.MATCH_MODE_STICKY)
-            .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
-            .build()
+        try {
+            val scanSettings = ScanSettings.Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                .setCallbackType(ScanSettings.CALLBACK_TYPE_FIRST_MATCH)
+                .setReportDelay(30000)
+                .setMatchMode(ScanSettings.MATCH_MODE_STICKY)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
+                .build()
 
-        logger.d("Starting monitoring beacons")
+            logger.d("Starting monitoring beacons")
 
-        adapter.bluetoothLeScanner.startScan(scanFilters, scanSettings, RadarLocationReceiver.getBeaconPendingIntent(context))
+            adapter.bluetoothLeScanner.startScan(scanFilters, scanSettings, RadarLocationReceiver.getBeaconPendingIntent(context))
+        } catch (e: SecurityException) {
+            logger.e("Error starting monitoring beacons", e)
+        }
+        
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/sdk/src/main/java/io/radar/sdk/RadarJobScheduler.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarJobScheduler.kt
@@ -39,9 +39,9 @@ class RadarJobScheduler : JobService() {
         internal fun scheduleJob(context: Context, location: Location, source: RadarLocationSource) {
             if (!Radar.initialized) {
                 // Radar must be initialized before using Radar.logger or other Radar members
-                // TODO better factoring of Radar members
                 Radar.initialize(context)
             }
+
             val componentName = ComponentName(context, RadarJobScheduler::class.java)
             val extras = PersistableBundle().apply {
                 putDouble(EXTRA_LATITUDE, location.latitude)
@@ -86,9 +86,9 @@ class RadarJobScheduler : JobService() {
     override fun onStartJob(params: JobParameters): Boolean {
         if (!Radar.initialized) {
             // Radar must be initialized before using Radar.logger or other Radar members
-            // TODO better factoring of Radar members
             Radar.initialize(this.applicationContext)
         }
+
         val extras = params.extras
         val latitude = extras.getDouble(EXTRA_LATITUDE)
         val longitude = extras.getDouble(EXTRA_LONGITUDE)
@@ -140,9 +140,9 @@ class RadarJobScheduler : JobService() {
     override fun onStopJob(params: JobParameters): Boolean {
         if (!Radar.initialized) {
             // Radar must be initialized before using Radar.logger or other Radar members
-            // TODO better factoring of Radar members
             Radar.initialize(this.applicationContext)
         }
+
         if (Radar.isTestKey()) {
             val extras = params.extras
             val latitude = extras.getDouble(EXTRA_LATITUDE)

--- a/sdk/src/main/java/io/radar/sdk/RadarJobScheduler.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarJobScheduler.kt
@@ -37,6 +37,11 @@ class RadarJobScheduler : JobService() {
         private val counter = AtomicInteger()
 
         internal fun scheduleJob(context: Context, location: Location, source: RadarLocationSource) {
+            if (!Radar.initialized) {
+                // Radar must be initialized before using Radar.logger or other Radar members
+                // TODO better factoring of Radar members
+                Radar.initialize(context)
+            }
             val componentName = ComponentName(context, RadarJobScheduler::class.java)
             val extras = PersistableBundle().apply {
                 putDouble(EXTRA_LATITUDE, location.latitude)
@@ -79,6 +84,11 @@ class RadarJobScheduler : JobService() {
     }
 
     override fun onStartJob(params: JobParameters): Boolean {
+        if (!Radar.initialized) {
+            // Radar must be initialized before using Radar.logger or other Radar members
+            // TODO better factoring of Radar members
+            Radar.initialize(this.applicationContext)
+        }
         val extras = params.extras
         val latitude = extras.getDouble(EXTRA_LATITUDE)
         val longitude = extras.getDouble(EXTRA_LONGITUDE)
@@ -128,6 +138,11 @@ class RadarJobScheduler : JobService() {
     }
 
     override fun onStopJob(params: JobParameters): Boolean {
+        if (!Radar.initialized) {
+            // Radar must be initialized before using Radar.logger or other Radar members
+            // TODO better factoring of Radar members
+            Radar.initialize(this.applicationContext)
+        }
         if (Radar.isTestKey()) {
             val extras = params.extras
             val latitude = extras.getDouble(EXTRA_LATITUDE)


### PR DESCRIPTION
We need to make the [same change](https://github.com/radarlabs/radar-sdk-android/compare/3.3.3...3.4.0) we made in 3.4.0 to RadarJobScheduler 