### PR TITLE
Don't remove the stopped bubble geofence in updateTracking() just because location is null

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -220,8 +220,10 @@ internal class RadarLocationManager(
                     this.startLocationUpdates(options.desiredAccuracy, options.desiredStoppedUpdateInterval, options.fastestStoppedUpdateInterval)
                 }
 
-                if (options.useStoppedGeofence && location != null) {
-                    this.replaceBubbleGeofence(location, true)
+                if (options.useStoppedGeofence) {
+                    if (location != null) {
+                        this.replaceBubbleGeofence(location, true)
+                    }
                 } else {
                     this.removeBubbleGeofences()
                 }
@@ -391,10 +393,12 @@ internal class RadarLocationManager(
 
     private fun removeBubbleGeofences() {
         geofencingClient.removeGeofences(RadarLocationReceiver.getBubbleGeofencePendingIntent(context))
+        logger.d("Removed bubble geofences")
     }
 
     private fun removeSyncedGeofences() {
         geofencingClient.removeGeofences(RadarLocationReceiver.getSyncedGeofencesPendingIntent(context))
+        logger.d("Removed synced geofences")
     }
 
     private fun removeAllGeofences() {


### PR DESCRIPTION
Noticed when testing the new Remote Tracking Options feature that sometimes location updates would stop after detecting a stop and then moving again.
It turns out the logic on Android is a little different than iOS.  This change mirrors how iOS works, and adds logging statements to make it more obvious when bubble and synced geofences are removed.