### PR TITLE
Update circleci to convenience image with api-30.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build_and_test:
     working_directory: ~/sdk
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2022.04.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Uses new CircleCI convenience images: https://circleci.com/developer/images?imageType=docker.