### PR TITLE
Fix beacons crash caused by BluetoothAdapter.getDefaultAdapter() == null

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.4.2'
+    radarVersion = '3.4.3'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2366,14 +2366,14 @@ object Radar {
         receiver?.onEventsReceived(context, events, user)
 
         for (event in events) {
-            logger.i("📍 Radar event received | type = ${RadarEvent.stringForType(event.type)}; link = https://radar.io/dashboard/events/${event._id}")
+            logger.i("📍 Radar event received | type = ${RadarEvent.stringForType(event.type)}; link = https://radar.com/dashboard/events/${event._id}")
         }
     }
 
     internal fun sendLocation(location: Location, user: RadarUser) {
         receiver?.onLocationUpdated(context, location, user)
 
-        logger.i("📍 Radar location updated | coordinates = (${location.latitude}, ${location.longitude}); accuracy = ${location.accuracy} meters; link = https://radar.io/dashboard/users/${user._id}")
+        logger.i("📍 Radar location updated | coordinates = (${location.latitude}, ${location.longitude}); accuracy = ${location.accuracy} meters; link = https://radar.com/dashboard/users/${user._id}")
     }
 
     internal fun sendClientLocation(location: Location, stopped: Boolean, source: RadarLocationSource) {

--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
@@ -300,6 +300,10 @@ internal class RadarBeaconManager(
             return
         }
 
+        if (!this::adapter.isInitialized) {
+            adapter = BluetoothAdapter.getDefaultAdapter()
+        }
+
         logger.d("Stopping ranging")
 
         handler.removeCallbacksAndMessages(TIMEOUT_TOKEN)

--- a/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
@@ -2,6 +2,7 @@ package io.radar.sdk
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -90,7 +91,7 @@ internal object RadarUtils {
     }
 
     internal fun getBluetoothSupported(context: Context): Boolean {
-        return context.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH)
+        return context.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH) && BluetoothAdapter.getDefaultAdapter() != null
     }
 
     internal fun getLocationAccuracyAuthorization(context: Context): String {


### PR DESCRIPTION
There are some cases where `context.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH)` can return `true` but `BluetoothAdapter.getDefaultAdapter()` can return `null`. Previously we only guarded against the former being `false` but not against the latter. This fixes that and adds an initialization check in `stopRanging()` to be extra safe.