### PR TITLE
sc-11273: Add a chainMetadata parameter to Radar.searchPlaces()

### DIFF
--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -49,6 +49,7 @@ class MainActivity : AppCompatActivity() {
         Radar.searchPlaces(
             1000,
             arrayOf("walmart"),
+            mapOf("orderPlaced" to "true"),
             null,
             null,
             10

--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -72,6 +72,8 @@ class MainActivity : AppCompatActivity() {
             Log.v("example", "Context: status = $status; location = $location; context?.geofences = ${context?.geofences}; context?.place = ${context?.place}; context?.country = ${context?.country}")
         }
 
+        // In the Radar dashboard settings (https://radar.com/dashboard/settings), add this to
+        // the chain metadata: {"mcdonalds":{"orderActive":"true"}}.
         Radar.searchPlaces(
             1000,
             arrayOf("mcdonalds"),

--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -74,8 +74,8 @@ class MainActivity : AppCompatActivity() {
 
         Radar.searchPlaces(
             1000,
-            arrayOf("walmart"),
-            mapOf("orderPlaced" to "true"),
+            arrayOf("mcdonalds"),
+            mapOf("orderActive" to "true"),
             null,
             null,
             10

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1302,6 +1302,7 @@ object Radar {
     fun searchPlaces(
         radius: Int,
         chains: Array<String>?,
+        chainMetadata: Map<String, String>? = null,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -1323,7 +1324,7 @@ object Radar {
                     return
                 }
 
-                apiClient.searchPlaces(location, radius, chains, categories, groups, limit, object : RadarApiClient.RadarSearchPlacesApiCallback {
+                apiClient.searchPlaces(location, radius, chains, chainMetadata, categories, groups, limit, object : RadarApiClient.RadarSearchPlacesApiCallback {
                     override fun onComplete(status: RadarStatus, res: JSONObject?, places: Array<RadarPlace>?) {
                         handler.post {
                             callback.onComplete(status, location, places)
@@ -1349,6 +1350,7 @@ object Radar {
     fun searchPlaces(
         radius: Int,
         chains: Array<String>?,
+        chainMetadata: Map<String, String>? = null,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -1357,6 +1359,7 @@ object Radar {
         searchPlaces(
             radius,
             chains,
+            chainMetadata,
             categories,
             groups,
             limit,
@@ -1376,6 +1379,7 @@ object Radar {
      * @param[near] The location to search.
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
      * @param[limit] The max number of places to return. A number between 1 and 100.
@@ -1386,6 +1390,7 @@ object Radar {
         near: Location,
         radius: Int,
         chains: Array<String>?,
+        chainMetadata: Map<String, String>? = null,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -1397,7 +1402,7 @@ object Radar {
             return
         }
 
-        apiClient.searchPlaces(near, radius, chains, categories, groups, limit, object : RadarApiClient.RadarSearchPlacesApiCallback {
+        apiClient.searchPlaces(near, radius, chains, chainMetadata, categories, groups, limit, object : RadarApiClient.RadarSearchPlacesApiCallback {
             override fun onComplete(status: RadarStatus, res: JSONObject?, places: Array<RadarPlace>?) {
                 handler.post {
                     callback.onComplete(status, near, places)
@@ -1414,6 +1419,7 @@ object Radar {
      * @param[near] The location to search.
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
      * @param[limit] The max number of places to return. A number between 1 and 100.
@@ -1423,6 +1429,7 @@ object Radar {
         near: Location,
         radius: Int,
         chains: Array<String>?,
+        chainMetadata: Map<String, String>?,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -1432,6 +1439,7 @@ object Radar {
             near,
             radius,
             chains,
+            chainMetadata,
             categories,
             groups,
             limit,

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1293,6 +1293,7 @@ object Radar {
      *
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
      * @param[limit] The max number of places to return. A number between 1 and 100.
@@ -1342,6 +1343,7 @@ object Radar {
      *
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
      * @param[limit] The max number of places to return. A number between 1 and 100.
@@ -1429,7 +1431,7 @@ object Radar {
         near: Location,
         radius: Int,
         chains: Array<String>?,
-        chainMetadata: Map<String, String>?,
+        chainMetadata: Map<String, String>? = null,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1293,6 +1293,31 @@ object Radar {
      *
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
+     * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
+     * @param[limit] The max number of places to return. A number between 1 and 100.
+     * @param[callback] A callback.
+     */
+    @JvmStatic
+    fun searchPlaces(
+        radius: Int,
+        chains: Array<String>?,
+        categories: Array<String>?,
+        groups: Array<String>?,
+        limit: Int?,
+        callback: RadarSearchPlacesCallback
+    ) {
+        searchPlaces(radius, chains, null, categories, groups, limit, callback)
+    }
+
+    /**
+     * Gets the device's current location, then searches for places (with or without chain-specific
+     * metadata) near that location, sorted by distance.
+     *
+     * @see [](https://radar.io/documentation/api#search-places)
+     *
+     * @param[radius] The radius to search, in meters. A number between 100 and 10000.
+     * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
      * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
@@ -1303,7 +1328,7 @@ object Radar {
     fun searchPlaces(
         radius: Int,
         chains: Array<String>?,
-        chainMetadata: Map<String, String>? = null,
+        chainMetadata: Map<String, String>?,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -1343,6 +1368,30 @@ object Radar {
      *
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
+     * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
+     * @param[limit] The max number of places to return. A number between 1 and 100.
+     * @param[block] A block callback.
+     */
+    fun searchPlaces(
+        radius: Int,
+        chains: Array<String>?,
+        categories: Array<String>?,
+        groups: Array<String>?,
+        limit: Int?,
+        block: (status: RadarStatus, location: Location?, places: Array<RadarPlace>?) -> Unit
+    ) {
+        searchPlaces(radius, chains, null, categories, groups, limit, block)
+    }
+
+    /**
+     * Gets the device's current location, then searches for places (with or without chain-specific
+     * metadata) near that location, sorted by distance.
+     *
+     * @see [](https://radar.io/documentation/api#search-places)
+     *
+     * @param[radius] The radius to search, in meters. A number between 100 and 10000.
+     * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
      * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
@@ -1352,7 +1401,7 @@ object Radar {
     fun searchPlaces(
         radius: Int,
         chains: Array<String>?,
-        chainMetadata: Map<String, String>? = null,
+        chainMetadata: Map<String, String>?,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -1381,6 +1430,33 @@ object Radar {
      * @param[near] The location to search.
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
+     * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
+     * @param[limit] The max number of places to return. A number between 1 and 100.
+     * @param[callback] A callback.
+     */
+    @JvmStatic
+    fun searchPlaces(
+        near: Location,
+        radius: Int,
+        chains: Array<String>?,
+        categories: Array<String>?,
+        groups: Array<String>?,
+        limit: Int?,
+        callback: RadarSearchPlacesCallback
+    ) {
+        searchPlaces(near, radius, chains, null, categories, groups, limit, callback)
+    }
+
+    /**
+     * Search for places (with or without chain-specific metadata) near a location, sorted by
+     * distance.
+     *
+     * @see [](https://radar.io/documentation/api#search-places)
+     *
+     * @param[near] The location to search.
+     * @param[radius] The radius to search, in meters. A number between 100 and 10000.
+     * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
      * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
@@ -1392,7 +1468,7 @@ object Radar {
         near: Location,
         radius: Int,
         chains: Array<String>?,
-        chainMetadata: Map<String, String>? = null,
+        chainMetadata: Map<String, String>?,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -1421,6 +1497,32 @@ object Radar {
      * @param[near] The location to search.
      * @param[radius] The radius to search, in meters. A number between 100 and 10000.
      * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
+     * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
+     * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
+     * @param[limit] The max number of places to return. A number between 1 and 100.
+     * @param[block] A block callback.
+     */
+    fun searchPlaces(
+        near: Location,
+        radius: Int,
+        chains: Array<String>?,
+        categories: Array<String>?,
+        groups: Array<String>?,
+        limit: Int?,
+        block: (status: RadarStatus, location: Location?, places: Array<RadarPlace>?) -> Unit
+    ) {
+        searchPlaces(near, radius, chains, null, categories, groups, limit, block)
+    }
+
+    /**
+     * Search for places (with or without chain-specific metadata) near a location, sorted by
+     * distance.
+     *
+     * @see [](https://radar.io/documentation/api#search-places)
+     *
+     * @param[near] The location to search.
+     * @param[radius] The radius to search, in meters. A number between 100 and 10000.
+     * @param[chains] An array of chain slugs to filter. See [](https://radar.io/documentation/places/chains)
      * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
@@ -1431,7 +1533,7 @@ object Radar {
         near: Location,
         radius: Int,
         chains: Array<String>?,
-        chainMetadata: Map<String, String>? = null,
+        chainMetadata: Map<String, String>?,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -475,7 +475,7 @@ internal class RadarApiClient(
         }
 
         chainMetadata?.entries?.forEach {
-            queryParams.append("&chainMetadata[:${it.key}]=:\"${it.value}\"");
+            queryParams.append("&chainMetadata%5B${it.key}%5D=%22${it.value}%22");
         }
 
         val host = RadarSettings.getHost(context)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -447,6 +447,7 @@ internal class RadarApiClient(
         location: Location,
         radius: Int,
         chains: Array<String>?,
+        chainMetadata: Map<String, String>?,
         categories: Array<String>?,
         groups: Array<String>?,
         limit: Int?,
@@ -471,6 +472,10 @@ internal class RadarApiClient(
         }
         if (groups?.isNotEmpty() == true) {
             queryParams.append("&groups=${groups.joinToString(separator = ",")}")
+        }
+
+        chainMetadata?.entries?.forEach {
+            queryParams.append("&chainMetadata[:${it.key}]=:\"${it.value}\"");
         }
 
         val host = RadarSettings.getHost(context)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -479,7 +479,7 @@ internal class RadarApiClient(
         }
 
         chainMetadata?.entries?.forEach {
-            queryParams.append("&chainMetadata%5B${it.key}%5D=%22${it.value}%22");
+            queryParams.append("&chainMetadata[${it.key}]=\"${it.value}\"");
         }
 
         val host = RadarSettings.getHost(context)

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -768,7 +768,7 @@ class RadarTest {
         val latch = CountDownLatch(1)
         var callbackStatus: Radar.RadarStatus? = null
 
-        Radar.searchPlaces(1000, arrayOf("walmart"), null, null, 100) { status, _, _ ->
+        Radar.searchPlaces(1000, arrayOf("walmart"), null, null, null, 100) { status, _, _ ->
             callbackStatus = status
             latch.countDown()
         }
@@ -787,7 +787,7 @@ class RadarTest {
         val latch = CountDownLatch(1)
         var callbackStatus: Radar.RadarStatus? = null
 
-        Radar.searchPlaces(1000, arrayOf("walmart"), null, null, 100) { status, _, _ ->
+        Radar.searchPlaces(1000, arrayOf("walmart"), null, null, null, 100) { status, _, _ ->
             callbackStatus = status
             latch.countDown()
         }
@@ -815,7 +815,7 @@ class RadarTest {
         var callbackLocation: Location? = null
         var callbackPlaces: Array<RadarPlace>? = null
 
-        Radar.searchPlaces(1000, arrayOf("walmart"), null, null, 100) { status, location, places ->
+        Radar.searchPlaces(1000, arrayOf("walmart"), null, null, null, 100) { status, location, places ->
             callbackStatus = status
             callbackLocation = location
             callbackPlaces = places
@@ -846,7 +846,7 @@ class RadarTest {
         var callbackLocation: Location? = null
         var callbackPlaces: Array<RadarPlace>? = null
 
-        Radar.searchPlaces(mockLocation, 1000, arrayOf("walmart"), null, null, 100) { status, location, places ->
+        Radar.searchPlaces(mockLocation, 1000, arrayOf("walmart"), null, null, null, 100) { status, location, places ->
             callbackStatus = status
             callbackLocation = location
             callbackPlaces = places

--- a/sdk/src/test/resources/search_places_chain_metadata.json
+++ b/sdk/src/test/resources/search_places_chain_metadata.json
@@ -1,0 +1,55 @@
+{
+    "meta": {
+        "code": 200
+    },
+    "places": [
+        {
+            "_id": "5dc9a5ed2004860034bc0767",
+            "categories": [
+                "food-beverage",
+                "restaurant",
+                "fast-food-restaurant"
+            ],
+            "chain": {
+                "domain": "mcdonalds.com",
+                "metadata": {
+                    "orderActive": "true"
+                },
+                "name": "McDonald's",
+                "slug": "mcdonalds"
+            },
+            "location": {
+                "coordinates": [
+                    -122.407687,
+                    37.789137
+                ],
+                "type": "Point"
+            },
+            "name": "McDonald's"
+        },
+        {
+            "_id" : "5dc9a5ee2004860034bc07e9",
+            "categories": [
+                "food-beverage",
+                "restaurant",
+                "fast-food-restaurant"
+            ],
+            "chain": {
+                "domain": "mcdonalds.com",
+                "metadata": {
+                    "orderActive": "true"
+                },
+                "name": "McDonald's",
+                "slug": "mcdonalds"
+            },
+            "location": {
+                "coordinates": [
+                    -122.4014864410883,
+                    37.78895421948911
+                ],
+                "type": "Point"
+            },
+            "name" : "McDonald's"
+        }
+    ]
+}


### PR DESCRIPTION
[sc-11273: [Android SDK] Add a new chainMetadata param to searchPlaces in the Android SDK](https://app.shortcut.com/radarlabs/story/11273/android-sdk-add-a-new-chainmetadata-param-to-searchplaces-in-the-android-sdk)

* Adds a `chainMetadata` argument to `Radar.searchPlaces()`.