### PR TITLE
sc-11338: Add metadata checks to custom RadarEvent unit tests

### DIFF
--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -1325,6 +1325,11 @@ class RadarTest {
         Radar.sendEvent(customType, metadata) { status, location, events, user ->
             callbackStatus = status
             callbackEvents = events
+
+            val customEventMetadata = events?.first()?.metadata
+            assertNotNull(customEventMetadata)
+            assertEquals("bar", customEventMetadata!!.get("foo"))
+
             latch.countDown()
         }
 
@@ -1349,6 +1354,11 @@ class RadarTest {
         Radar.sendEvent(customType, locationClientMock.mockLocation!!, null) { status, location, events, user ->
             callbackStatus = status
             callbackEvents = events
+
+            val customEventMetadata = events?.first()?.metadata
+            assertNotNull(customEventMetadata)
+            assertEquals("bar", customEventMetadata!!.get("foo"))
+
             latch.countDown()
         }
 


### PR DESCRIPTION
[sc-11338: [Android SDK] Add metadata checks for Radar.sendEvent() unit tests](https://app.shortcut.com/radarlabs/story/11338/android-sdk-add-metadata-checks-for-radar-sendevent-unit-tests)

* Added metadata assertions to the `Radar.sendEvent()` unit tests.