### PR TITLE
sc-11506: Add RadarTripOptions.approachingThreshold

### DIFF
--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -138,7 +138,8 @@ class MainActivity : AppCompatActivity() {
             null,
             "store",
             "123",
-            Radar.RadarRouteMode.CAR
+            Radar.RadarRouteMode.CAR,
+            approachingThreshold = 0
         )
         Radar.startTrip(tripOptions)
 

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -371,6 +371,9 @@ internal class RadarApiClient(
         }
         params.putOpt("mode", Radar.stringForMode(options.mode))
         params.putOpt("scheduledArrivalAt", RadarUtils.dateToISOString(options.scheduledArrivalAt))
+        if (options.approachingThreshold > 0) {
+            params.put("approachingThreshold", options.approachingThreshold)
+        }
 
         val host = RadarSettings.getHost(context)
         val uri = Uri.parse(host).buildUpon()

--- a/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
@@ -37,7 +37,9 @@ data class RadarTripOptions(
     /**
      * The scheduled arrival time for the trip.
      */
-    var scheduledArrivalAt: Date? = null
+    var scheduledArrivalAt: Date? = null,
+
+    var approachingThreshold: Int = 0
 ) {
 
     companion object {


### PR DESCRIPTION
[sc-11506: [Android SDK] Add approachingThreshold to Radar.startTrip() and .updateTrip()](https://app.shortcut.com/radarlabs/story/11506)

* Adds `RadarTripOptions.approachingThreshold`, which is passed as an `approachingThreshold` parameter when starting & updating trip calls.