### PR TITLE
support anonymous tracking

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -562,6 +562,17 @@ object Radar {
     }
 
     /**
+     * Enables anonymous tracking for privacy reasons. Avoids creating user records on the server and avoids sending any stable device IDs, user IDs, and user metadata
+     * to the server when calling `trackOnce()` or `startTracking()`. Disabled by default.
+     *
+     * @param[enabled] A boolean indicating whether anonymous tracking should be enabled.
+     */
+    @JvmStatic
+    fun setAnonymousTrackingEnabled(enabled: Boolean) {
+        RadarSettings.setAnonymousTrackingEnabled(context, enabled)
+    }
+
+    /**
      * Enables `adId` (Android advertising ID) collection. Disabled by default.
      *
      * @param[enabled] A boolean indicating whether `adId` should be collected.

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -175,15 +175,20 @@ internal class RadarApiClient(
         val params = JSONObject()
         val options = Radar.getTrackingOptions()
         val tripOptions = RadarSettings.getTripOptions(context)
+        val anonymous = RadarSettings.getAnonymousTrackingEnabled(context)
         try {
-            params.putOpt("id", RadarSettings.getId(context))
-            params.putOpt("installId", RadarSettings.getInstallId(context))
-            params.putOpt("userId", RadarSettings.getUserId(context))
-            params.putOpt("deviceId", RadarUtils.getDeviceId(context))
-            params.putOpt("description", RadarSettings.getDescription(context))
-            params.putOpt("metadata", RadarSettings.getMetadata(context))
-            if (RadarSettings.getAdIdEnabled(context)) {
-                params.putOpt("adId", RadarUtils.getAdId(context))
+            params.putOpt("anonymous", anonymous)
+            if (!anonymous) {
+                params.putOpt("id", RadarSettings.getId(context))
+                params.putOpt("installId", RadarSettings.getInstallId(context))
+                params.putOpt("userId", RadarSettings.getUserId(context))
+                params.putOpt("deviceId", RadarUtils.getDeviceId(context))
+                params.putOpt("description", RadarSettings.getDescription(context))
+                params.putOpt("metadata", RadarSettings.getMetadata(context))
+                if (RadarSettings.getAdIdEnabled(context)) {
+                    params.putOpt("adId", RadarUtils.getAdId(context))
+                }
+                params.putOpt("sessionId", RadarSettings.getSessionId(context))
             }
             params.putOpt("latitude", location.latitude)
             params.putOpt("longitude", location.longitude)
@@ -246,7 +251,6 @@ internal class RadarApiClient(
             if (beacons != null) {
                 params.putOpt("beacons", RadarBeacon.toJson(beacons))
             }
-            params.putOpt("sessionId", RadarSettings.getSessionId(context))
             params.putOpt("locationAuthorization", RadarUtils.getLocationAuthorization(context))
             params.putOpt("locationAccuracyAuthorization", RadarUtils.getLocationAccuracyAuthorization(context))
             params.putOpt("trackingOptions", Radar.getTrackingOptions().toJson())

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -179,10 +179,11 @@ internal class RadarApiClient(
         try {
             params.putOpt("anonymous", anonymous)
             if (anonymous) {
-                params.putOpt("geofenceIds", RadarState.getGeofenceIds(context)?.toTypedArray())
+                params.putOpt("deviceId", "anonymous")
+                params.putOpt("geofenceIds", JSONArray(RadarState.getGeofenceIds(context)))
                 params.putOpt("placeId", RadarState.getPlaceId(context))
-                params.putOpt("regionIds", RadarState.getRegionIds(context)?.toTypedArray())
-                params.putOpt("beaconIds", RadarState.getBeaconIds(context)?.toTypedArray())
+                params.putOpt("regionIds", JSONArray(RadarState.getRegionIds(context)))
+                params.putOpt("beaconIds", JSONArray(RadarState.getBeaconIds(context)))
             } else {
                 params.putOpt("id", RadarSettings.getId(context))
                 params.putOpt("installId", RadarSettings.getInstallId(context))

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -571,13 +571,6 @@ internal class RadarLocationManager(
                     nearbyGeofences: Array<RadarGeofence>?,
                     config: RadarConfig?
                 ) {
-                    if (user != null) {
-                        val inGeofences = user.geofences != null && user.geofences.isNotEmpty()
-                        val atPlace = user.place != null
-                        val canExit = inGeofences || atPlace
-                        RadarState.setCanExit(context, canExit)
-                    }
-
                     locationManager.replaceSyncedGeofences(nearbyGeofences)
 
                     if (foregroundService != null && foregroundService.updatesOnly) {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -18,6 +18,7 @@ internal object RadarSettings {
     private const val KEY_USER_ID = "user_id"
     private const val KEY_DESCRIPTION = "user_description"
     private const val KEY_METADATA = "user_metadata"
+    private const val KEY_ANONYMOUS = "anonymous"
     private const val KEY_AD_ID_ENABLED = "ad_id_enabled"
     private const val KEY_TRACKING = "background_tracking"
     private const val KEY_TRACKING_OPTIONS = "tracking_options"
@@ -112,6 +113,14 @@ internal object RadarSettings {
     internal fun setMetadata(context: Context, metadata: JSONObject?) {
         val metadataJSON = metadata?.toString()
         getSharedPreferences(context).edit { putString(KEY_METADATA, metadataJSON) }
+    }
+
+    internal fun getAnonymousTrackingEnabled(context: Context): Boolean {
+        return getSharedPreferences(context).getBoolean(KEY_ANONYMOUS, false)
+    }
+
+    internal fun setAnonymousTrackingEnabled(context: Context, enabled: Boolean) {
+        getSharedPreferences(context).edit { putBoolean(KEY_ANONYMOUS, enabled) }
     }
 
     internal fun getAdIdEnabled(context: Context): Boolean {

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -27,6 +27,10 @@ internal object RadarState {
     private const val KEY_LAST_FAILED_STOPPED_LOCATION_ACCURACY = "last_failed_stopped_location_accuracy"
     private const val KEY_LAST_FAILED_STOPPED_LOCATION_PROVIDER = "last_failed_stopped_location_provider"
     private const val KEY_LAST_FAILED_STOPPED_LOCATION_TIME = "last_failed_stopped_location_time"
+    private const val KEY_GEOFENCE_IDS = "geofence_ids"
+    private const val KEY_PLACE_ID = "place_id"
+    private const val KEY_REGION_IDS = "region_ids"
+    private const val KEY_BEACON_IDS = "beacon_ids"
 
     private fun getSharedPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
@@ -177,6 +181,38 @@ internal object RadarState {
             putString(KEY_LAST_FAILED_STOPPED_LOCATION_PROVIDER, location.provider)
             putLong(KEY_LAST_FAILED_STOPPED_LOCATION_TIME, location.time)
         }
+    }
+
+    internal fun getGeofenceIds(context: Context): MutableSet<String>? {
+        return getSharedPreferences(context).getStringSet(KEY_GEOFENCE_IDS, null)
+    }
+
+    internal fun setGeofenceIds(context: Context, geofenceIds: Set<String>?) {
+        getSharedPreferences(context).edit { putStringSet(KEY_GEOFENCE_IDS, geofenceIds) }
+    }
+
+    internal fun getPlaceId(context: Context): String? {
+        return getSharedPreferences(context).getString(KEY_PLACE_ID, null)
+    }
+
+    internal fun setPlaceId(context: Context, placeId: String?) {
+        getSharedPreferences(context).edit { putString(KEY_PLACE_ID, placeId) }
+    }
+
+    internal fun getRegionIds(context: Context): MutableSet<String>? {
+        return getSharedPreferences(context).getStringSet(KEY_REGION_IDS, null)
+    }
+
+    internal fun setRegionIds(context: Context, regionIds: Set<String>?) {
+        getSharedPreferences(context).edit { putStringSet(KEY_REGION_IDS, regionIds) }
+    }
+
+    internal fun getBeaconIds(context: Context): MutableSet<String>? {
+        return getSharedPreferences(context).getStringSet(KEY_BEACON_IDS, null)
+    }
+
+    internal fun setBeaconIds(context: Context, beaconIds: Set<String>?) {
+        getSharedPreferences(context).edit { putStringSet(KEY_BEACON_IDS, beaconIds) }
     }
 
 }


### PR DESCRIPTION
- Exposes `Radar.setAnonymousTrackingEnabled()`. When enabled, avoids sending any stable device IDs, user IDs, or user metadata to `POST /track`
- TODO: Send current geofenceIds, placeId, and regionIds to avoid duplicate events