### PR TITLE
sc-12253: Add RadarTripOptions.approachingThreshold to JSON serialization

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
@@ -39,6 +39,10 @@ data class RadarTripOptions(
      */
     var scheduledArrivalAt: Date? = null,
 
+    /**
+     * The trip approaching threshold setting for the trip (in minutes). Overrides the
+     * geofence-level and project-level trip approaching threshold settings.
+     */
     var approachingThreshold: Int = 0
 ) {
 
@@ -50,6 +54,7 @@ data class RadarTripOptions(
         internal const val KEY_DESTINATION_GEOFENCE_EXTERNAL_ID = "destinationGeofenceExternalId"
         internal const val KEY_MODE = "mode"
         internal const val KEY_SCHEDULED_ARRIVAL_AT = "scheduledArrivalAt"
+        internal const val KEY_APPROACHING_THRESHOLD = "approachingThreshold"
 
         @JvmStatic
         fun fromJson(obj: JSONObject): RadarTripOptions {
@@ -68,6 +73,7 @@ data class RadarTripOptions(
                 scheduledArrivalAt = if (obj.has(KEY_SCHEDULED_ARRIVAL_AT)) Date(obj.optLong(
                     KEY_SCHEDULED_ARRIVAL_AT
                 )) else null,
+                approachingThreshold = obj.optInt(KEY_APPROACHING_THRESHOLD)
             )
         }
 
@@ -81,6 +87,11 @@ data class RadarTripOptions(
         obj.put(KEY_DESTINATION_GEOFENCE_EXTERNAL_ID, destinationGeofenceExternalId)
         obj.put(KEY_MODE, Radar.stringForMode(mode))
         obj.put(KEY_SCHEDULED_ARRIVAL_AT, scheduledArrivalAt?.time)
+
+        if (approachingThreshold > 0) {
+            obj.put(KEY_APPROACHING_THRESHOLD, approachingThreshold)
+        }
+
         return obj
     }
 
@@ -100,7 +111,8 @@ data class RadarTripOptions(
                 this.destinationGeofenceTag == other.destinationGeofenceTag &&
                 this.destinationGeofenceExternalId == other.destinationGeofenceExternalId &&
                 this.mode == other.mode &&
-                this.scheduledArrivalAt?.time == other.scheduledArrivalAt?.time
+                this.scheduledArrivalAt?.time == other.scheduledArrivalAt?.time &&
+                this.approachingThreshold == other.approachingThreshold
     }
 
 }

--- a/sdk/src/test/java/io/radar/sdk/model/RadarTripOptionsTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/model/RadarTripOptionsTest.kt
@@ -17,7 +17,7 @@ import java.util.*
 class RadarTripOptionsTest {
 
     @Test
-    fun testFromJsonWithNonZeroApproachingThreshold() {
+    fun testToFromJsonWithNonZeroApproachingThreshold() {
         val tripOptions = RadarTripOptions(
             externalId = "externalId",
             destinationGeofenceTag = "destinationGeofenceTag",
@@ -30,10 +30,17 @@ class RadarTripOptionsTest {
         assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
         assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
         assertEquals(5, jsonObject["approachingThreshold"])
+
+        // Deserialize it and compare them again
+        val deserializedTripOptions = RadarTripOptions.fromJson(jsonObject)
+        assertEquals(tripOptions.externalId, deserializedTripOptions.externalId)
+        assertEquals(tripOptions.destinationGeofenceTag, deserializedTripOptions.destinationGeofenceTag)
+        assertEquals(tripOptions.destinationGeofenceExternalId, deserializedTripOptions.destinationGeofenceExternalId)
+        assertEquals(tripOptions.approachingThreshold, deserializedTripOptions.approachingThreshold)
     }
 
     @Test
-    fun testFromJsonWithZeroApproachingThresholdIgnoresThreshold() {
+    fun testToFromJsonWithZeroApproachingThresholdIgnoresThreshold() {
         val tripOptions = RadarTripOptions(
             externalId = "externalId",
             destinationGeofenceTag = "destinationGeofenceTag",
@@ -46,10 +53,17 @@ class RadarTripOptionsTest {
         assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
         assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
         assertFalse(jsonObject.has("approachingThreshold"))
+
+        // Deserialize it and compare them again
+        val deserializedTripOptions = RadarTripOptions.fromJson(jsonObject)
+        assertEquals(tripOptions.externalId, deserializedTripOptions.externalId)
+        assertEquals(tripOptions.destinationGeofenceTag, deserializedTripOptions.destinationGeofenceTag)
+        assertEquals(tripOptions.destinationGeofenceExternalId, deserializedTripOptions.destinationGeofenceExternalId)
+        assertEquals(tripOptions.approachingThreshold, deserializedTripOptions.approachingThreshold) // both are 0
     }
 
     @Test
-    fun testFromJsonWithNegativeApproachingThresholdIgnoresThreshold() {
+    fun testToFromJsonWithNegativeApproachingThresholdIgnoresThreshold() {
         val tripOptions = RadarTripOptions(
             externalId = "externalId",
             destinationGeofenceTag = "destinationGeofenceTag",
@@ -62,6 +76,13 @@ class RadarTripOptionsTest {
         assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
         assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
         assertFalse(jsonObject.has("approachingThreshold"))
+
+        // Deserialize it and compare them again
+        val deserializedTripOptions = RadarTripOptions.fromJson(jsonObject)
+        assertEquals(tripOptions.externalId, deserializedTripOptions.externalId)
+        assertEquals(tripOptions.destinationGeofenceTag, deserializedTripOptions.destinationGeofenceTag)
+        assertEquals(tripOptions.destinationGeofenceExternalId, deserializedTripOptions.destinationGeofenceExternalId)
+        assertNotEquals(tripOptions.approachingThreshold, deserializedTripOptions.approachingThreshold)
     }
 
     @Test

--- a/sdk/src/test/java/io/radar/sdk/model/RadarTripOptionsTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/model/RadarTripOptionsTest.kt
@@ -1,0 +1,123 @@
+package io.radar.sdk.model
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.radar.sdk.RadarTrackingOptions
+import io.radar.sdk.RadarTripOptions
+import junit.framework.Assert.assertNull
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class RadarTripOptionsTest {
+
+    @Test
+    fun testFromJsonWithNonZeroApproachingThreshold() {
+        val tripOptions = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 5
+        )
+        val jsonObject = tripOptions.toJson()
+
+        assertEquals("externalId", jsonObject["externalId"])
+        assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
+        assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
+        assertEquals(5, jsonObject["approachingThreshold"])
+    }
+
+    @Test
+    fun testFromJsonWithZeroApproachingThresholdIgnoresThreshold() {
+        val tripOptions = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 0 // values less than 1 aren't serialized
+        )
+        val jsonObject = tripOptions.toJson()
+
+        assertEquals("externalId", jsonObject["externalId"])
+        assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
+        assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
+        assertFalse(jsonObject.has("approachingThreshold"))
+    }
+
+    @Test
+    fun testFromJsonWithNegativeApproachingThresholdIgnoresThreshold() {
+        val tripOptions = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = -5 // negative values aren't serialized
+        )
+        val jsonObject = tripOptions.toJson()
+
+        assertEquals("externalId", jsonObject["externalId"])
+        assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
+        assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
+        assertFalse(jsonObject.has("approachingThreshold"))
+    }
+
+    @Test
+    fun testIsEqualsWithDifferentApproachingThresholdsReturnsFalse() {
+        val tripOptions1 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = -5
+        )
+
+        val tripOptions2 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        assertNotEquals(tripOptions1, tripOptions2)
+    }
+
+    @Test
+    fun testIsEqualsWithUnsetApproachingThresholdsReturnsFalse() {
+        val tripOptions1 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+        )
+
+        val tripOptions2 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        assertNotEquals(tripOptions1, tripOptions2)
+    }
+
+    @Test
+    fun testIsEqualsWithSameApproachingThresholdsReturnsTrue() {
+        val tripOptions1 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        val tripOptions2 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        assertEquals(tripOptions1, tripOptions2)
+    }
+
+}


### PR DESCRIPTION
[sc-12253: [Android SDK] Add approachingThreshold to RadarTripOptions JSON serialization](https://app.shortcut.com/radarlabs/story/12253)

* Added `approachingThreshold` to `RadarTripOptions.toJson()`, `.fromJson()`, and `isEquals()`.
* Added unit tests for the above.