### PR TITLE
check adapter for null before initializing

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
@@ -602,8 +602,9 @@ internal class RadarBeaconManager(
     }
 
     private fun isBluetoothSupported(context: Context): Boolean {
-        if (!this::adapter.isInitialized) {
-            adapter = BluetoothAdapter.getDefaultAdapter()
+        val defaultAdapter = BluetoothAdapter.getDefaultAdapter()
+        if (defaultAdapter != null && !this::adapter.isInitialized) {
+            adapter = defaultAdapter
         }
 
         return context.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH) && adapter != null && adapter.bluetoothLeScanner != null

--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconManager.kt
@@ -602,9 +602,11 @@ internal class RadarBeaconManager(
     }
 
     private fun isBluetoothSupported(context: Context): Boolean {
-        val defaultAdapter = BluetoothAdapter.getDefaultAdapter()
-        if (defaultAdapter != null && !this::adapter.isInitialized) {
-            adapter = defaultAdapter
+        if(!this::adapter.isInitialized) {
+            val defaultAdapter = BluetoothAdapter.getDefaultAdapter()
+            if (defaultAdapter != null) {
+                adapter = defaultAdapter
+            }
         }
 
         return context.packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH) && adapter != null && adapter.bluetoothLeScanner != null


### PR DESCRIPTION
Fixes an exception where a `lateinit` variable is getting set to null