### PR TITLE
Upgrade play services location to 21.0.1

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.gms:play-services-ads-identifier:17.1.0"
-    implementation "com.google.android.gms:play-services-location:18.0.0"
+    implementation "com.google.android.gms:play-services-location:21.0.1"
     compileOnly "com.huawei.hms:location:6.4.0.300"
     testImplementation "androidx.test.ext:junit:1.1.3"
     testImplementation "org.robolectric:robolectric:4.5.1"


### PR DESCRIPTION
Upgrade `play-services-location` to `21.0.1`

Release notes for `play-services-location` [here](https://developers.google.com/android/guides/releases#november_03_2022).