### PR TITLE
3.5.8 release

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,8 @@
 # Migration guides
 
+## 3.5.7 to 3.5.8
+- If your application depends on classes in `com.google.android.gms.location`, you may need to update your code to reflect the changes made to `play-services-location` in version 20.0.0, as documented [here](https://developers.google.com/android/guides/releases#october_13_2022).  Version 3.5.8 of the Radar SDK updates `play-location-services` to version 21.0.1. Besides the Radar SDK, if your application does not depend on classes in `com.google.android.gms.location` no migrations are necessary.
+ 
 ## 3.3.x to 3.4.x
 
 - `foregroundService` is no longer available in `RadarTrackingOptions`. This has been replaced by `Radar.setForegroundServiceOptions` instead.

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.5.8-beta.2'
+    radarVersion = '3.5.8'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.gms:play-services-ads-identifier:17.1.0"
-    implementation "com.google.android.gms:play-services-location:18.0.0"
+    implementation "com.google.android.gms:play-services-location:21.0.1"
     compileOnly "com.huawei.hms:location:6.4.0.300"
     testImplementation "androidx.test.ext:junit:1.1.3"
     testImplementation "org.robolectric:robolectric:4.5.1"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.5.7'
+    radarVersion = '3.5.8-beta.2'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -185,7 +185,6 @@ internal class RadarLocationManager(
         if (tracking) {
             if (options.foregroundServiceEnabled) {
                 val foregroundService = RadarSettings.getForegroundService(context)
-                    ?: RadarTrackingOptions.RadarTrackingOptionsForegroundService()
                 if (!foregroundService.updatesOnly) {
                     this.startForegroundService(foregroundService)
                 }
@@ -553,7 +552,7 @@ internal class RadarLocationManager(
         val options = Radar.getTrackingOptions()
         val foregroundService = RadarSettings.getForegroundService(context)
 
-        if (foregroundService != null && foregroundService.updatesOnly) {
+        if (options.foregroundServiceEnabled && foregroundService.updatesOnly) {
             this.startForegroundService(foregroundService)
         }
 
@@ -573,7 +572,7 @@ internal class RadarLocationManager(
                 ) {
                     locationManager.replaceSyncedGeofences(nearbyGeofences)
 
-                    if (foregroundService != null && foregroundService.updatesOnly) {
+                    if (options.foregroundServiceEnabled && foregroundService.updatesOnly) {
                         locationManager.stopForegroundService()
                     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -192,14 +192,17 @@ internal object RadarSettings {
         getSharedPreferences(context).edit { remove(KEY_REMOTE_TRACKING_OPTIONS) }
     }
 
-    internal fun getForegroundService(context: Context): RadarTrackingOptions.RadarTrackingOptionsForegroundService? {
+    internal fun getForegroundService(context: Context): RadarTrackingOptions.RadarTrackingOptionsForegroundService {
         val foregroundJson = getSharedPreferences(context).getString(KEY_FOREGROUND_SERVICE, null)
-        return if (foregroundJson == null) {
-            null
-        } else {
+        var foregroundService: RadarTrackingOptions.RadarTrackingOptionsForegroundService? = null
+        if (foregroundJson != null) {
             val foregroundObj = JSONObject(foregroundJson)
-            RadarTrackingOptions.RadarTrackingOptionsForegroundService.fromJson(foregroundObj)
+            foregroundService = RadarTrackingOptions.RadarTrackingOptionsForegroundService.fromJson(foregroundObj)
         }
+        if (foregroundService == null) {
+            foregroundService = RadarTrackingOptions.RadarTrackingOptionsForegroundService()
+        }
+        return foregroundService
     }
 
     internal fun setForegroundService(


### PR DESCRIPTION
- Upgrades `play-services-location` to 21.0.1
- Uses `foregroundServiceEnabled` to start and stop the foreground service