### PR TITLE
publish SNAPSHOT releases from pre-releases not from pushing to develop

### DIFF
--- a/.github/workflows/radar-release-actions.yml
+++ b/.github/workflows/radar-release-actions.yml
@@ -2,7 +2,8 @@
 name: Radar Release Action
 on:
   release:
-    types: [ published ]
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+    types: [ released ]
 jobs:
   Build-And-Publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/radar-snapshot-action.yml
+++ b/.github/workflows/radar-snapshot-action.yml
@@ -1,9 +1,9 @@
 # Trigger an SDK publication to SNAPSHOTS repo on Maven Central when a commit is pushed to develop.
 name: Radar Snapshot Action
 on:
-  push:
-    branches:
-      - develop
+  release:
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+    types: [ prereleased ]
 jobs:
   Build-And-Publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR does 2 things:
1) Stop publishing pre-releases as normal releases to maven
2) Publish SNAPSHOTs from pre-releases, not when merging to the `develop` branch