### PR TITLE
Include approachingThreshold in tripOptions

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
@@ -90,7 +90,9 @@ data class RadarTripOptions(
         obj.put(KEY_DESTINATION_GEOFENCE_EXTERNAL_ID, destinationGeofenceExternalId)
         obj.put(KEY_MODE, Radar.stringForMode(mode))
         obj.put(KEY_SCHEDULED_ARRIVAL_AT, scheduledArrivalAt?.time)
-        obj.put(KEY_APPROACHING_THRESHOLD, approachingThreshold)
+        if (approachingThreshold > 0) {
+            obj.put(KEY_APPROACHING_THRESHOLD, approachingThreshold)
+        }
         return obj
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
@@ -50,6 +50,7 @@ data class RadarTripOptions(
         internal const val KEY_DESTINATION_GEOFENCE_EXTERNAL_ID = "destinationGeofenceExternalId"
         internal const val KEY_MODE = "mode"
         internal const val KEY_SCHEDULED_ARRIVAL_AT = "scheduledArrivalAt"
+        internal const val KEY_APPROACHING_THRESHOLD = "approachingThreshold"
 
         @JvmStatic
         fun fromJson(obj: JSONObject): RadarTripOptions {
@@ -75,6 +76,7 @@ data class RadarTripOptions(
                         RadarUtils.isoStringToDate(obj.optString(KEY_SCHEDULED_ARRIVAL_AT))
                     }
                 } else null,
+                approachingThreshold = obj.optInt(KEY_APPROACHING_THRESHOLD)
             )
         }
 
@@ -88,6 +90,7 @@ data class RadarTripOptions(
         obj.put(KEY_DESTINATION_GEOFENCE_EXTERNAL_ID, destinationGeofenceExternalId)
         obj.put(KEY_MODE, Radar.stringForMode(mode))
         obj.put(KEY_SCHEDULED_ARRIVAL_AT, scheduledArrivalAt?.time)
+        obj.put(KEY_APPROACHING_THRESHOLD, approachingThreshold)
         return obj
     }
 
@@ -107,7 +110,8 @@ data class RadarTripOptions(
                 this.destinationGeofenceTag == other.destinationGeofenceTag &&
                 this.destinationGeofenceExternalId == other.destinationGeofenceExternalId &&
                 this.mode == other.mode &&
-                this.scheduledArrivalAt?.time == other.scheduledArrivalAt?.time
+                this.scheduledArrivalAt?.time == other.scheduledArrivalAt?.time &&
+                this.approachingThreshold == other.approachingThreshold
     }
 
 }

--- a/sdk/src/test/java/io/radar/sdk/model/RadarTripOptionsTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/model/RadarTripOptionsTest.kt
@@ -1,0 +1,144 @@
+package io.radar.sdk.model
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.radar.sdk.RadarTrackingOptions
+import io.radar.sdk.RadarTripOptions
+import junit.framework.Assert.assertNull
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class RadarTripOptionsTest {
+
+    @Test
+    fun testToFromJsonWithNonZeroApproachingThreshold() {
+        val tripOptions = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 5
+        )
+        val jsonObject = tripOptions.toJson()
+
+        assertEquals("externalId", jsonObject["externalId"])
+        assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
+        assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
+        assertEquals(5, jsonObject["approachingThreshold"])
+
+        // Deserialize it and compare them again
+        val deserializedTripOptions = RadarTripOptions.fromJson(jsonObject)
+        assertEquals(tripOptions.externalId, deserializedTripOptions.externalId)
+        assertEquals(tripOptions.destinationGeofenceTag, deserializedTripOptions.destinationGeofenceTag)
+        assertEquals(tripOptions.destinationGeofenceExternalId, deserializedTripOptions.destinationGeofenceExternalId)
+        assertEquals(tripOptions.approachingThreshold, deserializedTripOptions.approachingThreshold)
+    }
+
+    @Test
+    fun testToFromJsonWithZeroApproachingThresholdIgnoresThreshold() {
+        val tripOptions = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 0 // values less than 1 aren't serialized
+        )
+        val jsonObject = tripOptions.toJson()
+
+        assertEquals("externalId", jsonObject["externalId"])
+        assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
+        assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
+        assertFalse(jsonObject.has("approachingThreshold"))
+
+        // Deserialize it and compare them again
+        val deserializedTripOptions = RadarTripOptions.fromJson(jsonObject)
+        assertEquals(tripOptions.externalId, deserializedTripOptions.externalId)
+        assertEquals(tripOptions.destinationGeofenceTag, deserializedTripOptions.destinationGeofenceTag)
+        assertEquals(tripOptions.destinationGeofenceExternalId, deserializedTripOptions.destinationGeofenceExternalId)
+        assertEquals(tripOptions.approachingThreshold, deserializedTripOptions.approachingThreshold) // both are 0
+    }
+
+    @Test
+    fun testToFromJsonWithNegativeApproachingThresholdIgnoresThreshold() {
+        val tripOptions = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = -5 // negative values aren't serialized
+        )
+        val jsonObject = tripOptions.toJson()
+
+        assertEquals("externalId", jsonObject["externalId"])
+        assertEquals("destinationGeofenceTag", jsonObject["destinationGeofenceTag"])
+        assertEquals("destinationGeofenceExternalId", jsonObject["destinationGeofenceExternalId"])
+        assertFalse(jsonObject.has("approachingThreshold"))
+
+        // Deserialize it and compare them again
+        val deserializedTripOptions = RadarTripOptions.fromJson(jsonObject)
+        assertEquals(tripOptions.externalId, deserializedTripOptions.externalId)
+        assertEquals(tripOptions.destinationGeofenceTag, deserializedTripOptions.destinationGeofenceTag)
+        assertEquals(tripOptions.destinationGeofenceExternalId, deserializedTripOptions.destinationGeofenceExternalId)
+        assertNotEquals(tripOptions.approachingThreshold, deserializedTripOptions.approachingThreshold)
+    }
+
+    @Test
+    fun testIsEqualsWithDifferentApproachingThresholdsReturnsFalse() {
+        val tripOptions1 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = -5
+        )
+
+        val tripOptions2 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        assertNotEquals(tripOptions1, tripOptions2)
+    }
+
+    @Test
+    fun testIsEqualsWithUnsetApproachingThresholdsReturnsFalse() {
+        val tripOptions1 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+        )
+
+        val tripOptions2 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        assertNotEquals(tripOptions1, tripOptions2)
+    }
+
+    @Test
+    fun testIsEqualsWithSameApproachingThresholdsReturnsTrue() {
+        val tripOptions1 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        val tripOptions2 = RadarTripOptions(
+            externalId = "externalId",
+            destinationGeofenceTag = "destinationGeofenceTag",
+            destinationGeofenceExternalId = "destinationGeofenceExternalId",
+            approachingThreshold = 11
+        )
+
+        assertEquals(tripOptions1, tripOptions2)
+    }
+
+}


### PR DESCRIPTION
Part of the work for https://linear.app/radarlabs/issue/MOB-56/include-trip-approaching-threshold-in-radartripoptions-helper

Haven't touched Kotlin code before so all the normal disclaimers apply. Also didn't see any obvious way to test this. Let's talk about testing and the rest of the cross platform dev concerns when we sesh @tjulien 

Working on the iOS part now.