### PR TITLE
Surface center, radius, and location for geofences & places

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/model/RadarGeofence.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarGeofence.kt
@@ -35,11 +35,23 @@ class RadarGeofence(
      */
     val metadata: JSONObject?,
 
+
     /**
      * The geometry of the geofence.
      */
-    val geometry: RadarGeofenceGeometry?
-) {
+    val geometry: RadarGeofenceGeometry?,
+
+    /**
+     * The radius of the geofence.
+     */
+    val geometryRadius: Double?,
+
+    /**
+     * The center of the geofence.
+     */
+    val geometryCenter: RadarCoordinate?,
+
+    ) {
 
     internal companion object {
         private const val FIELD_ID = "_id"
@@ -48,9 +60,9 @@ class RadarGeofence(
         private const val FIELD_EXTERNAL_ID = "externalId"
         private const val FIELD_METADATA = "metadata"
         private const val FIELD_TYPE = "type"
+        private const val FIELD_GEOMETRY = "geometry"
         private const val FIELD_GEOMETRY_RADIUS = "geometryRadius"
         private const val FIELD_GEOMETRY_CENTER = "geometryCenter"
-        private const val FIELD_GEOMETRY = "geometry"
         private const val FIELD_COORDINATES = "coordinates"
 
         private const val TYPE_CIRCLE = "circle"
@@ -104,7 +116,7 @@ class RadarGeofence(
                 else -> null
             } ?: RadarCircleGeometry(RadarCoordinate(0.0, 0.0), 0.0)
 
-            return RadarGeofence(id, description, tag, externalId, metadata, geometry)
+            return RadarGeofence(id, description, tag, externalId, metadata, geometry, radius, center)
         }
 
         @JvmStatic
@@ -139,6 +151,8 @@ class RadarGeofence(
         obj.putOpt(FIELD_EXTERNAL_ID, this.externalId)
         obj.putOpt(FIELD_DESCRIPTION, this.description)
         obj.putOpt(FIELD_METADATA, this.metadata)
+        obj.putOpt(FIELD_GEOMETRY_CENTER, this.geometryCenter?.toJson())
+        obj.putOpt(FIELD_GEOMETRY_RADIUS, this.geometryRadius)
         return obj
     }
 

--- a/sdk/src/main/java/io/radar/sdk/model/RadarGeofence.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarGeofence.kt
@@ -41,16 +41,6 @@ class RadarGeofence(
      */
     val geometry: RadarGeofenceGeometry?,
 
-    /**
-     * The radius of the geofence.
-     */
-    val geometryRadius: Double?,
-
-    /**
-     * The center of the geofence.
-     */
-    val geometryCenter: RadarCoordinate?,
-
     ) {
 
     internal companion object {
@@ -116,7 +106,7 @@ class RadarGeofence(
                 else -> null
             } ?: RadarCircleGeometry(RadarCoordinate(0.0, 0.0), 0.0)
 
-            return RadarGeofence(id, description, tag, externalId, metadata, geometry, radius, center)
+            return RadarGeofence(id, description, tag, externalId, metadata, geometry)
         }
 
         @JvmStatic
@@ -151,8 +141,19 @@ class RadarGeofence(
         obj.putOpt(FIELD_EXTERNAL_ID, this.externalId)
         obj.putOpt(FIELD_DESCRIPTION, this.description)
         obj.putOpt(FIELD_METADATA, this.metadata)
-        obj.putOpt(FIELD_GEOMETRY_CENTER, this.geometryCenter?.toJson())
-        obj.putOpt(FIELD_GEOMETRY_RADIUS, this.geometryRadius)
+        this.geometry?.let { geometry ->
+            when (geometry) {
+                is RadarCircleGeometry -> {
+                    obj.putOpt(FIELD_GEOMETRY_CENTER, geometry.center.toJson())
+                    obj.putOpt(FIELD_GEOMETRY_RADIUS, geometry.radius)
+                }
+                is RadarPolygonGeometry -> {
+                    obj.putOpt(FIELD_GEOMETRY_CENTER, geometry.center.toJson())
+                    obj.putOpt(FIELD_GEOMETRY_RADIUS, geometry.radius)
+                }
+            }
+        }
+        
         return obj
     }
 

--- a/sdk/src/main/java/io/radar/sdk/model/RadarPlace.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarPlace.kt
@@ -125,6 +125,7 @@ class RadarPlace(
         obj.putOpt(FIELD_CHAIN, this.chain?.toJson())
         obj.putOpt(FIELD_GROUP, this.group)
         obj.putOpt(FIELD_METADATA, this.metadata)
+        obj.putOpt(FIELD_LOCATION, this.location.toJson())
         return obj
     }
 

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -1022,6 +1022,14 @@ class RadarTest {
         assertEquals(Radar.RadarStatus.SUCCESS, callbackStatus)
         assertEquals(mockLocation, callbackLocation)
         assertGeofencesOk(callbackGeofences)
+
+        // test that a geofence.toJson has a radius and geometryCenter
+        val geofence = callbackGeofences!!.first()
+        val geofenceJson = geofence.toJson()
+        assertNotNull(geofenceJson)
+        assertTrue(geofenceJson.has("geometryRadius"))
+        assertTrue(geofenceJson.has("geometryCenter"))
+
     }
 
     @Test


### PR DESCRIPTION
For https://linear.app/radarlabs/issue/MOB-77/surface-coordinates-from-search-geofences-call-in-rn

I've tested the iOS equivalent in the react native sample app. The android example app in the sdk runs with these changes, but I'm trying to verify that this works correctly on React Native on android. After that, I think we'd be good to go.