### PR TITLE
Always clear last location if successful track

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -292,9 +292,6 @@ internal class RadarApiClient(
         var replays = Radar.getReplays()
         val replayCount = replays.size
         var nowMS = System.currentTimeMillis()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            nowMS = SystemClock.elapsedRealtimeNanos() / 1000000
-        }
         val replaying = replayCount > 0 && options.replay == RadarTrackingOptions.RadarTrackingOptionsReplay.ALL
         if (replaying) {
             val replayList = mutableListOf<JSONObject>()

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -331,10 +331,9 @@ internal class RadarApiClient(
 
                 if (replaying) {
                     Radar.clearReplays()
-                } else {
-                    RadarState.setLastFailedStoppedLocation(context, null)
                 }
 
+                RadarState.setLastFailedStoppedLocation(context, null)
                 Radar.flushLogs()
 
                 val config = RadarConfig.fromJson(res)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -326,10 +326,7 @@ internal class RadarApiClient(
                     return
                 }
 
-                if (replaying) {
-                    Radar.clearReplays()
-                }
-
+                Radar.clearReplays()
                 RadarState.setLastFailedStoppedLocation(context, null)
                 Radar.flushLogs()
 


### PR DESCRIPTION
There was a bug that reared it's head only if you were tracking with `replayed: stops`, failed a track call, and then changed to `replay: all` where the last call before changing to `all` would be sent up after clearing the replay buffer in the next successful `/track/replay`.