### PR TITLE
Improve logic for `opened_app` conversions

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.7.1-beta.8'
+    radarVersion = '3.7.1-beta.9'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.7.1-beta.9'
+    radarVersion = '3.7.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.7.1-beta.5'
+    radarVersion = '3.7.1-beta.6'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.7.1-beta.7'
+    radarVersion = '3.7.1-beta.8'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.7.0'
+    radarVersion = '3.7.1-beta.5'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "androidx.core:core-ktx:1.7.0"
-    implementation "com.google.android.gms:play-services-location:18.0.0"
+    implementation "com.google.android.gms:play-services-location:21.0.1"
     compileOnly "com.huawei.hms:location:6.4.0.300"
     compileOnly "com.google.android.play:integrity:1.0.2"
     testImplementation "androidx.test.ext:junit:1.1.3"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "androidx.core:core-ktx:1.7.0"
-    implementation "com.google.android.gms:play-services-location:21.0.1"
+    implementation "com.google.android.gms:play-services-location:[20.0.0, 21.0.1]"
     compileOnly "com.huawei.hms:location:6.4.0.300"
     compileOnly "com.google.android.play:integrity:1.0.2"
     testImplementation "androidx.test.ext:junit:1.1.3"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.7.1-beta.6'
+    radarVersion = '3.7.1-beta.7'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -74,15 +74,6 @@ dependencies {
     testImplementation 'org.json:json:20211205'
 }
 
-publishing {
-    repositories {
-        maven {
-            name = 'devLocalMaven'
-            url = '~/dev/mavenRepository'
-        }
-    }
-}
-
 task androidSourcesJar(type: Jar) {
     group 'publishing'
     archiveClassifier.set("sources")

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -66,12 +66,21 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "androidx.core:core-ktx:1.7.0"
-    implementation "com.google.android.gms:play-services-location:[20.0.0, 21.0.1]"
+    implementation "com.google.android.gms:play-services-location:21.0.1"
     compileOnly "com.huawei.hms:location:6.4.0.300"
     compileOnly "com.google.android.play:integrity:1.0.2"
     testImplementation "androidx.test.ext:junit:1.1.3"
     testImplementation "org.robolectric:robolectric:4.5.1"
     testImplementation 'org.json:json:20211205'
+}
+
+publishing {
+    repositories {
+        maven {
+            name = 'devLocalMaven'
+            url = '~/dev/mavenRepository'
+        }
+    }
 }
 
 task androidSourcesJar(type: Jar) {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "androidx.core:core-ktx:1.7.0"
-    implementation "com.google.android.gms:play-services-location:21.0.1"
+    implementation "com.google.android.gms:play-services-location:18.0.0"
     compileOnly "com.huawei.hms:location:6.4.0.300"
     compileOnly "com.google.android.play:integrity:1.0.2"
     testImplementation "androidx.test.ext:junit:1.1.3"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.os.Handler
+import android.util.Log
 import io.radar.sdk.model.*
 import io.radar.sdk.model.RadarEvent.RadarEventVerification
 import io.radar.sdk.util.RadarLogBuffer
@@ -491,6 +492,7 @@ object Radar {
 
         this.initialized = true
 
+        logOpenedAppConversion()
         logger.i("📍️ Radar initialized")
     }
 
@@ -2813,6 +2815,20 @@ object Radar {
                     }
                 }
             })
+    }
+
+    internal fun logOpenedAppConversion() {
+        // if opened_app has been logged in the last 1000 milliseconds, don't log it again
+        val timestamp = System.currentTimeMillis()
+        val lastAppOpenTime = RadarSettings.getLastAppOpenTimeMillis(context)
+        if (timestamp - lastAppOpenTime > 1000) {
+            RadarSettings.updateLastAppOpenTimeMillis(context)
+            sendLogConversionRequest("opened_app", callback = object : RadarLogConversionCallback {
+                override fun onComplete(status: Radar.RadarStatus, event: RadarEvent?) {
+                    Log.i(null, "Conversion name = ${event?.conversionName}: status = $status; event = $event")
+                }
+            })
+        }
     }
 
     /**

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -745,12 +745,12 @@ object Radar {
      */
     @JvmStatic
     fun trackOnce(desiredAccuracy: RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy, beacons: Boolean, callback: RadarTrackCallback? = null) {
-        this.logger.i("trackOnce()", RadarLogType.SDK_CALL)
         if (!initialized) {
             callback?.onComplete(RadarStatus.ERROR_PUBLISHABLE_KEY)
 
             return
         }
+        this.logger.i("trackOnce()", RadarLogType.SDK_CALL)
 
         locationManager.getLocation(desiredAccuracy, RadarLocationSource.FOREGROUND_LOCATION, object : RadarLocationCallback {
             override fun onComplete(status: RadarStatus, location: Location?, stopped: Boolean) {

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2712,6 +2712,7 @@ object Radar {
     /**
      * Logs a conversion.
      *
+     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.
@@ -2758,6 +2759,7 @@ object Radar {
     /**
      * Logs a conversion.
      *
+     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.
@@ -2783,6 +2785,7 @@ object Radar {
     /**
      * Logs a conversion with revenue.
      *
+     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.
@@ -2806,6 +2809,7 @@ object Radar {
     /**
      * Logs a conversion with revenue.
      *
+     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.
@@ -2861,10 +2865,10 @@ object Radar {
     }
 
     internal fun logOpenedAppConversion() {
-        // if opened_app has been logged in the last 250 milliseconds, don't log it again
+        // if opened_app has been logged in the last 1000 milliseconds, don't log it again
         val timestamp = System.currentTimeMillis()
         val lastAppOpenTime = RadarSettings.getLastAppOpenTimeMillis(context)
-        if (timestamp - lastAppOpenTime > 250) {
+        if (timestamp - lastAppOpenTime > 1000) {
             RadarSettings.updateLastAppOpenTimeMillis(context)
             sendLogConversionRequest("opened_app", callback = object : RadarLogConversionCallback {
                 override fun onComplete(status: Radar.RadarStatus, event: RadarEvent?) {

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2709,7 +2709,6 @@ object Radar {
         })
     }
 
-    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion.
      *
@@ -2756,7 +2755,6 @@ object Radar {
         })
     }
 
-    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion.
      *
@@ -2782,7 +2780,6 @@ object Radar {
         })
     }
 
-    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion with revenue.
      *
@@ -2806,7 +2803,6 @@ object Radar {
         logConversion(name, nonNullMetadata, callback)
     }
 
-    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion with revenue.
      *

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2726,7 +2726,7 @@ object Radar {
             return
         }
 
-        // if trackOnce() has been returned in the last 60 seconds, don't call it again
+        // if track() has been returned in the last 60 seconds, don't call it again
         val timestampSeconds = System.currentTimeMillis() / 1000
         val lastTrackedTime = RadarSettings.getLastTrackedTime(context)
         val isLastTrackRecent = timestampSeconds - lastTrackedTime < 60

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2709,10 +2709,10 @@ object Radar {
         })
     }
 
+    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion.
      *
-     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.
@@ -2756,10 +2756,10 @@ object Radar {
         })
     }
 
+    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion.
      *
-     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.
@@ -2782,10 +2782,10 @@ object Radar {
         })
     }
 
+    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion with revenue.
      *
-     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.
@@ -2806,10 +2806,10 @@ object Radar {
         logConversion(name, nonNullMetadata, callback)
     }
 
+    // TODO replace the docs url once the docs are updated
     /**
      * Logs a conversion with revenue.
      *
-     * TODO replace this url once the docs are updated
      * @see [](https://radar.com/documentation/api#send-a-custom-event)
      *
      * @param[name] The name of the conversion.

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -446,8 +446,6 @@ object Radar {
             this.logger = RadarLogger(this.context)
         }
 
-        RadarSettings.updateSessionId(this.context)
-
         if (publishableKey != null) {
             RadarSettings.setPublishableKey(this.context, publishableKey)
         }
@@ -455,6 +453,9 @@ object Radar {
         if (!this::apiClient.isInitialized) {
             this.apiClient = RadarApiClient(this.context, logger)
         }
+
+        RadarSettings.updateSessionId(this.context)
+
         if (!this::batteryManager.isInitialized) {
             this.batteryManager = RadarBatteryManager(this.context)
         }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -6,12 +6,11 @@ import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.os.Handler
-import android.util.Log
 import io.radar.sdk.model.*
 import io.radar.sdk.model.RadarEvent.RadarEventVerification
 import io.radar.sdk.util.RadarLogBuffer
-import io.radar.sdk.util.RadarSimpleLogBuffer
 import io.radar.sdk.util.RadarReplayBuffer
+import io.radar.sdk.util.RadarSimpleLogBuffer
 import io.radar.sdk.util.RadarSimpleReplayBuffer
 import org.json.JSONObject
 import java.util.*
@@ -2868,7 +2867,7 @@ object Radar {
             RadarSettings.updateLastAppOpenTimeMillis(context)
             sendLogConversionRequest("opened_app", callback = object : RadarLogConversionCallback {
                 override fun onComplete(status: Radar.RadarStatus, event: RadarEvent?) {
-                    Log.i(null, "Conversion name = ${event?.conversionName}: status = $status; event = $event")
+                    logger.i("Conversion name = ${event?.conversionName}: status = $status; event = $event")
                 }
             })
         }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -492,7 +492,6 @@ object Radar {
 
         this.initialized = true
 
-        logOpenedAppConversion()
         logger.i("📍️ Radar initialized")
     }
 
@@ -2818,10 +2817,10 @@ object Radar {
     }
 
     internal fun logOpenedAppConversion() {
-        // if opened_app has been logged in the last 1000 milliseconds, don't log it again
+        // if opened_app has been logged in the last 250 milliseconds, don't log it again
         val timestamp = System.currentTimeMillis()
         val lastAppOpenTime = RadarSettings.getLastAppOpenTimeMillis(context)
-        if (timestamp - lastAppOpenTime > 1000) {
+        if (timestamp - lastAppOpenTime > 250) {
             RadarSettings.updateLastAppOpenTimeMillis(context)
             sendLogConversionRequest("opened_app", callback = object : RadarLogConversionCallback {
                 override fun onComplete(status: Radar.RadarStatus, event: RadarEvent?) {

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -38,10 +38,9 @@ internal class RadarActivityLifecycleCallbacks : Application.ActivityLifecycleCa
     }
 
     override fun onActivityResumed(activity: Activity) {
-        var updated = false
         if (count == 0) {
             try {
-                updated = RadarSettings.updateSessionId(activity.applicationContext)
+                val updated = RadarSettings.updateSessionId(activity.applicationContext)
                 if (updated) {
                     val usage = "resume"
                     Radar.apiClient.getConfig(usage, false, object : RadarApiClient.RadarGetConfigApiCallback {
@@ -58,14 +57,7 @@ internal class RadarActivityLifecycleCallbacks : Application.ActivityLifecycleCa
         count++
         foreground = count > 0
 
-        if (!updated) {
-            // opened_app is logged when sessionId is updated, don't log it twice
-            Radar.sendLogConversionRequest("opened_app", callback = object : Radar.RadarLogConversionCallback {
-                override fun onComplete(status: Radar.RadarStatus, event: RadarEvent?) {
-                    Log.i(null, "Conversion name = ${event?.conversionName}: status = $status; event = $event in resume")
-                }
-            })
-        }
+        Radar.logOpenedAppConversion()
 
         updatePermissionsDenied(activity)
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -9,7 +9,6 @@ import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import io.radar.sdk.model.RadarConfig
-import io.radar.sdk.model.RadarEvent
 import kotlin.math.max
 
 internal class RadarActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -59,9 +59,9 @@ internal class RadarActivityLifecycleCallbacks : Application.ActivityLifecycleCa
         updatePermissionsDenied(activity)
 
         // TODO: log opened_app conversions once the desired logic is hashed out
-//        Radar.logConversion("opened_app") { status, event ->
-//            Log.i(null, "Conversion name = ${event?.conversionName}: status = $status; event = $event")
-//        }
+        Radar.logConversion("opened_app") { status, event ->
+            Log.i(null, "Conversion name = ${event?.conversionName}: status = $status; event = $event")
+        }
     }
 
     override fun onActivityPaused(activity: Activity) {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -2,7 +2,9 @@ package io.radar.sdk
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.core.content.edit
+import io.radar.sdk.model.RadarEvent
 import io.radar.sdk.model.RadarFeatureSettings
 import org.json.JSONObject
 import java.text.DecimalFormat
@@ -78,6 +80,13 @@ internal object RadarSettings {
         val sessionIdSeconds = getSharedPreferences(context).getLong(KEY_SESSION_ID, 0)
         if (timestampSeconds - sessionIdSeconds > 300) {
             getSharedPreferences(context).edit { putLong(KEY_SESSION_ID, timestampSeconds) }
+
+            // log opened_app conversion whenever sessionId is updated
+            Radar.sendLogConversionRequest("opened_app", callback = object : Radar.RadarLogConversionCallback {
+                override fun onComplete(status: Radar.RadarStatus, event: RadarEvent?) {
+                    Log.i(null, "Conversion name = ${event?.conversionName}: status = $status; event = $event in updateSessionId")
+                }
+            })
 
             Radar.logger.d("New session | sessionId = ${this.getSessionId(context)}")
 

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -2,9 +2,7 @@ package io.radar.sdk
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.core.content.edit
-import io.radar.sdk.model.RadarEvent
 import io.radar.sdk.model.RadarFeatureSettings
 import org.json.JSONObject
 import java.text.DecimalFormat
@@ -35,6 +33,7 @@ internal object RadarSettings {
     private const val KEY_PERMISSIONS_DENIED = "permissions_denied"
     private const val KEY_LAST_TRACKED_TIME = "last_tracked_time"
     private const val KEY_VERIFIED_HOST = "verified_host"
+    private const val KEY_LAST_APP_OPEN_TIME = "last_app_open_time"
 
     private const val KEY_OLD_UPDATE_INTERVAL = "dwell_delay"
     private const val KEY_OLD_UPDATE_INTERVAL_RESPONSIVE = 60000
@@ -81,12 +80,7 @@ internal object RadarSettings {
         if (timestampSeconds - sessionIdSeconds > 300) {
             getSharedPreferences(context).edit { putLong(KEY_SESSION_ID, timestampSeconds) }
 
-            // log opened_app conversion whenever sessionId is updated
-            Radar.sendLogConversionRequest("opened_app", callback = object : Radar.RadarLogConversionCallback {
-                override fun onComplete(status: Radar.RadarStatus, event: RadarEvent?) {
-                    Log.i(null, "Conversion name = ${event?.conversionName}: status = $status; event = $event in updateSessionId")
-                }
-            })
+            Radar.logOpenedAppConversion()
 
             Radar.logger.d("New session | sessionId = ${this.getSessionId(context)}")
 
@@ -306,6 +300,15 @@ internal object RadarSettings {
 
     internal fun setUserDebug(context: Context, userDebug: Boolean) {
         getSharedPreferences(context).edit { putBoolean(KEY_USER_DEBUG, userDebug) }
+    }
+
+    internal fun getLastAppOpenTimeMillis(context: Context): Long {
+        return getSharedPreferences(context).getLong(KEY_LAST_APP_OPEN_TIME, 0)
+    }
+
+    internal fun updateLastAppOpenTimeMillis(context: Context) {
+        val timestampSeconds = System.currentTimeMillis()
+        getSharedPreferences(context).edit { putLong(KEY_LAST_APP_OPEN_TIME, timestampSeconds) }
     }
 
 }


### PR DESCRIPTION
call `opened_app` when the app enters the foreground and whenever `sessionId` is updated