### PR TITLE
Expose getHost and getPublishableKey

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.6'
+    radarVersion = '3.8.5'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.5-beta.4'
+    radarVersion = '3.8.6'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.4'
+    radarVersion = '3.8.5-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.5-beta.1'
+    radarVersion = '3.8.5-beta.4'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1135,14 +1135,30 @@ object Radar {
         return RadarSettings.getTracking(context)
     }
 
+   /** 
+    *  Returns a string of the radar host.
+    *
+    *  @return A string of the radar host.
+    */
     @JvmStatic
-    fun getHost(): String {
+    fun getHost(): String? {
+        if (!initialized) {
+            return null
+        }
 
         return RadarSettings.getHost(context)
     }
 
+   /**
+    * Returns a string of the publishable key.
+    *
+    * @return A string of the publishable key.
+    */
     @JvmStatic
     fun getPublishableKey(): String? {
+        if (!initialized) {
+            return null
+        }
 
         return RadarSettings.getPublishableKey(context)
     }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1135,6 +1135,18 @@ object Radar {
         return RadarSettings.getTracking(context)
     }
 
+    @JvmStatic
+    fun getHost(): String {
+
+        return RadarSettings.getHost(context)
+    }
+
+    @JvmStatic
+    fun getPublishableKey(): String? {
+
+        return RadarSettings.getPublishableKey(context)
+    }
+
     /**
      * Returns the current tracking options.
      *


### PR DESCRIPTION
The react native UI kit needs access to the host and publishable key. On iOS, we can access the `RadarSettings` directly,  but on Android it's an `internal object`. Exposing these in `Radar.kt` allows `react-native-radar` to get these values on Android.