### PR TITLE
migrate to Integrity API Standard Requests

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-    implementation "com.google.android.play:integrity:1.0.2"
+    implementation "com.google.android.play:integrity:1.2.0"
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.gms:play-services-location:21.0.1"
     compileOnly "com.huawei.hms:location:6.4.0.300"
-    implementation "com.google.android.play:integrity:1.2.0"
+    compileOnly "com.google.android.play:integrity:1.2.0"
     testImplementation "androidx.test.ext:junit:1.1.3"
     testImplementation "org.robolectric:robolectric:4.5.1"
     testImplementation 'org.json:json:20211205'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.12-beta.5'
+    radarVersion = '3.8.13'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.11'
+    radarVersion = '3.8.12-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.gms:play-services-location:21.0.1"
     compileOnly "com.huawei.hms:location:6.4.0.300"
-    compileOnly "com.google.android.play:integrity:1.0.2"
+    implementation "com.google.android.play:integrity:1.2.0"
     testImplementation "androidx.test.ext:junit:1.1.3"
     testImplementation "org.robolectric:robolectric:4.5.1"
     testImplementation 'org.json:json:20211205'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:1.1.3"
     testImplementation "org.robolectric:robolectric:4.5.1"
     testImplementation 'org.json:json:20211205'
+    testImplementation "com.google.android.play:integrity:1.2.0"
 }
 
 task androidSourcesJar(type: Jar) {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.12-beta.1'
+    radarVersion = '3.8.12-beta.5'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -521,8 +521,7 @@ object Radar {
                 RadarSettings.setFeatureSettings(context, config.featureSettings)
 
                 if (config.googlePlayProjectNumber != null) {
-                    // Create an instance of a standard integrity manager.
-                    IntegrityManagerFactory.createStandard(context)
+                    // Create an instance of a standard integrity manager
                     val standardIntegrityManager = IntegrityManagerFactory.createStandard(context)
                     standardIntegrityManager.prepareIntegrityToken(
                         StandardIntegrityManager.PrepareIntegrityTokenRequest.builder()
@@ -954,9 +953,8 @@ object Radar {
                         }
 
                         if (config.nonce == null) {
-                            // TODO(travis): What to do here?
                             handler.post {
-                                callback?.onComplete(RadarStatus.ERROR_NETWORK)
+                                callback?.onComplete(RadarStatus.ERROR_UNKNOWN)
                             }
 
                             return

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -990,7 +990,7 @@ object Radar {
                         val stringToHash = verificationManager.getRequestHash(location, config.nonce);
                         val requestHash = hashSHA256(stringToHash)
 
-                        verificationManager.getIntegrityToken(config.googlePlayProjectNumber, config.nonce) { integrityToken, integrityException ->
+                        verificationManager.getIntegrityToken(Radar.standardIntegrityTokenProvider, requestHash) { integrityToken, integrityException ->
                             apiClient.track(location, RadarState.getStopped(context), RadarActivityLifecycleCallbacks.foreground, RadarLocationSource.FOREGROUND_LOCATION, false, null, true, integrityToken, integrityException, false, callback = object : RadarApiClient.RadarTrackApiCallback {
                                 override fun onComplete(
                                     status: RadarStatus,
@@ -1065,7 +1065,18 @@ object Radar {
                             return
                         }
 
-                        verificationManager.getIntegrityToken(config.googlePlayProjectNumber, config.nonce) { integrityToken, integrityException ->
+                        if (config.nonce == null) {
+                            handler.post {
+                                callback?.onComplete(RadarStatus.ERROR_UNKNOWN)
+                            }
+
+                            return
+                        }
+
+                        val stringToHash = verificationManager.getRequestHash(location, config.nonce);
+                        val requestHash = hashSHA256(stringToHash)
+
+                        verificationManager.getIntegrityToken(Radar.standardIntegrityTokenProvider, requestHash) { integrityToken, integrityException ->
                             apiClient.track(location, RadarState.getStopped(context), RadarActivityLifecycleCallbacks.foreground, RadarLocationSource.FOREGROUND_LOCATION, false, null, true, integrityToken, integrityException, true, object : RadarApiClient.RadarTrackApiCallback {
                                 override fun onComplete(
                                     status: RadarStatus,

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -538,6 +538,12 @@ object Radar {
             override fun onComplete(config: RadarConfig) {
                 locationManager.updateTrackingFromMeta(config?.meta)
                 RadarSettings.setFeatureSettings(context, config?.meta.featureSettings)
+                if (config?.googlePlayProjectNumber != null) {
+                    RadarSettings.setGooglePlayProjectNumber(
+                        context,
+                        config?.googlePlayProjectNumber
+                    )
+                }
             }
         })
 
@@ -945,46 +951,37 @@ object Radar {
             this.verificationManager = RadarVerificationManager(this.context, this.logger)
         }
 
-        val usage = "verify"
-        apiClient.getConfig(usage, true, object : RadarApiClient.RadarGetConfigApiCallback {
-            override fun onComplete(config: RadarConfig) {
-                locationManager.getLocation(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, RadarLocationSource.FOREGROUND_LOCATION, object : RadarLocationCallback {
-                    override fun onComplete(status: RadarStatus, location: Location?, stopped: Boolean) {
-                        if (status != RadarStatus.SUCCESS || location == null) {
-                            handler.post {
-                                callback?.onComplete(status)
-                            }
+        val googlePlayProjectNumber = RadarSettings.getGooglePlayProjectNumber(this.context);
 
-                            return
-                        }
-
-                        if (config.nonce == null) {
-                            logger.d("Error missing nonce for trackVerified", RadarLogType.SDK_ERROR)
-
-                            return
-                        }
-
-                        val requestHash = verificationManager.getRequestHash(location, config.nonce);
-
-                        verificationManager.getIntegrityToken(config.googlePlayProjectNumber, requestHash) { integrityToken, integrityException ->
-                            apiClient.track(location, RadarState.getStopped(context), RadarActivityLifecycleCallbacks.foreground, RadarLocationSource.FOREGROUND_LOCATION, false, null, true, integrityToken, integrityException, false, callback = object : RadarApiClient.RadarTrackApiCallback {
-                                override fun onComplete(
-                                    status: RadarStatus,
-                                    res: JSONObject?,
-                                    events: Array<RadarEvent>?,
-                                    user: RadarUser?,
-                                    nearbyGeofences: Array<RadarGeofence>?,
-                                    config: RadarConfig?,
-                                    token: String?
-                                ) {
-                                    handler.post {
-                                        callback?.onComplete(status, location, events, user)
-                                    }
-                                }
-                            })
-                        }
+        locationManager.getLocation(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, RadarLocationSource.FOREGROUND_LOCATION, object : RadarLocationCallback {
+            override fun onComplete(status: RadarStatus, location: Location?, stopped: Boolean) {
+                if (status != RadarStatus.SUCCESS || location == null) {
+                    handler.post {
+                        callback?.onComplete(status)
                     }
-                })
+
+                    return
+                }
+
+                val requestHash = verificationManager.getRequestHash(location);
+
+                verificationManager.getIntegrityToken(googlePlayProjectNumber, requestHash) { integrityToken, integrityException ->
+                    apiClient.track(location, RadarState.getStopped(context), RadarActivityLifecycleCallbacks.foreground, RadarLocationSource.FOREGROUND_LOCATION, false, null, true, integrityToken, integrityException, false, callback = object : RadarApiClient.RadarTrackApiCallback {
+                        override fun onComplete(
+                            status: RadarStatus,
+                            res: JSONObject?,
+                            events: Array<RadarEvent>?,
+                            user: RadarUser?,
+                            nearbyGeofences: Array<RadarGeofence>?,
+                            config: RadarConfig?,
+                            token: String?
+                        ) {
+                            handler.post {
+                                callback?.onComplete(status, location, events, user)
+                            }
+                        }
+                    })
+                }
             }
         })
     }
@@ -1030,46 +1027,37 @@ object Radar {
             this.verificationManager = RadarVerificationManager(this.context, this.logger)
         }
 
-        val usage = "verify"
-        apiClient.getConfig(usage, true, object : RadarApiClient.RadarGetConfigApiCallback {
-            override fun onComplete(config: RadarConfig) {
-                locationManager.getLocation(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, RadarLocationSource.FOREGROUND_LOCATION, object : RadarLocationCallback {
-                    override fun onComplete(status: RadarStatus, location: Location?, stopped: Boolean) {
-                        if (status != RadarStatus.SUCCESS || location == null) {
-                            handler.post {
-                                callback?.onComplete(status)
-                            }
+        val googlePlayProjectNumber = RadarSettings.getGooglePlayProjectNumber(this.context);
 
-                            return
-                        }
-
-                        if (config.nonce == null) {
-                            logger.d("Error missing nonce for trackVerified", RadarLogType.SDK_ERROR)
-
-                            return
-                        }
-
-                        val requestHash = verificationManager.getRequestHash(location, config.nonce);
-
-                        verificationManager.getIntegrityToken(config.googlePlayProjectNumber, requestHash) { integrityToken, integrityException ->
-                            apiClient.track(location, RadarState.getStopped(context), RadarActivityLifecycleCallbacks.foreground, RadarLocationSource.FOREGROUND_LOCATION, false, null, true, integrityToken, integrityException, true, object : RadarApiClient.RadarTrackApiCallback {
-                                override fun onComplete(
-                                    status: RadarStatus,
-                                    res: JSONObject?,
-                                    events: Array<RadarEvent>?,
-                                    user: RadarUser?,
-                                    nearbyGeofences: Array<RadarGeofence>?,
-                                    config: RadarConfig?,
-                                    token: String?
-                                ) {
-                                    handler.post {
-                                        callback?.onComplete(status, token)
-                                    }
-                                }
-                            })
-                        }
+        locationManager.getLocation(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, RadarLocationSource.FOREGROUND_LOCATION, object : RadarLocationCallback {
+            override fun onComplete(status: RadarStatus, location: Location?, stopped: Boolean) {
+                if (status != RadarStatus.SUCCESS || location == null) {
+                    handler.post {
+                        callback?.onComplete(status)
                     }
-                })
+
+                    return
+                }
+
+                val requestHash = verificationManager.getRequestHash(location);
+
+                verificationManager.getIntegrityToken(googlePlayProjectNumber, requestHash) { integrityToken, integrityException ->
+                    apiClient.track(location, RadarState.getStopped(context), RadarActivityLifecycleCallbacks.foreground, RadarLocationSource.FOREGROUND_LOCATION, false, null, true, integrityToken, integrityException, true, object : RadarApiClient.RadarTrackApiCallback {
+                        override fun onComplete(
+                            status: RadarStatus,
+                            res: JSONObject?,
+                            events: Array<RadarEvent>?,
+                            user: RadarUser?,
+                            nearbyGeofences: Array<RadarGeofence>?,
+                            config: RadarConfig?,
+                            token: String?
+                        ) {
+                            handler.post {
+                                callback?.onComplete(status, token)
+                            }
+                        }
+                    })
+                }
             }
         })
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -52,9 +52,6 @@ internal class RadarActivityLifecycleCallbacks(
                     val usage = "resume"
                     Radar.apiClient.getConfig(usage, false, object : RadarApiClient.RadarGetConfigApiCallback {
                         override fun onComplete(config: RadarConfig) {
-                            if (RadarSettings.getFraudEnabled(activity.applicationContext)) {
-                                Radar.warmupStandardIntegrityTokenProvider(config)
-                            }
                             Radar.locationManager.updateTrackingFromMeta(config.meta)
                             RadarSettings.setFeatureSettings(activity.applicationContext, config.meta.featureSettings)
                         }

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -52,6 +52,7 @@ internal class RadarActivityLifecycleCallbacks(
                     val usage = "resume"
                     Radar.apiClient.getConfig(usage, false, object : RadarApiClient.RadarGetConfigApiCallback {
                         override fun onComplete(config: RadarConfig) {
+                            Radar.warmupStandardIntegrityTokenProvider(config)
                             Radar.locationManager.updateTrackingFromMeta(config.meta)
                             RadarSettings.setFeatureSettings(activity.applicationContext, config.meta.featureSettings)
                         }

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -52,7 +52,9 @@ internal class RadarActivityLifecycleCallbacks(
                     val usage = "resume"
                     Radar.apiClient.getConfig(usage, false, object : RadarApiClient.RadarGetConfigApiCallback {
                         override fun onComplete(config: RadarConfig) {
-                            Radar.warmupStandardIntegrityTokenProvider(config)
+                            if (RadarSettings.getFraudEnabled(activity.applicationContext)) {
+                                Radar.warmupStandardIntegrityTokenProvider(config)
+                            }
                             Radar.locationManager.updateTrackingFromMeta(config.meta)
                             RadarSettings.setFeatureSettings(activity.applicationContext, config.meta.featureSettings)
                         }

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -102,6 +102,8 @@ internal class RadarApiClient(
             "X-Radar-Device-Model" to RadarUtils.deviceModel,
             "X-Radar-Device-OS" to RadarUtils.deviceOS,
             "X-Radar-Device-Type" to RadarUtils.deviceType,
+            "cf-ipcountry" to "CA",
+            "cf-region-code" to "MB",
             "X-Radar-SDK-Version" to RadarUtils.sdkVersion
         )
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -102,8 +102,6 @@ internal class RadarApiClient(
             "X-Radar-Device-Model" to RadarUtils.deviceModel,
             "X-Radar-Device-OS" to RadarUtils.deviceOS,
             "X-Radar-Device-Type" to RadarUtils.deviceType,
-            "cf-ipcountry" to "CA",
-            "cf-region-code" to "MB",
             "X-Radar-SDK-Version" to RadarUtils.sdkVersion
         )
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -112,7 +112,10 @@ internal class RadarApiClient(
         val queryParams = StringBuilder()
         queryParams.append("installId=${RadarSettings.getInstallId(context)}")
         queryParams.append("&sessionId=${RadarSettings.getSessionId(context)}")
-        queryParams.append("&id=${RadarSettings.getId(context)}")
+        val id = RadarSettings.getId(context);
+        if (id != null) {
+            queryParams.append("&id=${id}")
+        }
         queryParams.append("&locationAuthorization=${RadarUtils.getLocationAuthorization(context)}")
         queryParams.append("&locationAccuracyAuthorization=${RadarUtils.getLocationAccuracyAuthorization(context)}")
         queryParams.append("&verified=$verified")

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -283,8 +283,7 @@ internal object RadarSettings {
     }
 
     internal fun getHost(context: Context): String {
-        return "https://travis-radar.ngrok.io";
-        //return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
+        return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
     }
 
     internal fun setPermissionsDenied(context: Context, denied: Boolean) {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -273,8 +273,7 @@ internal object RadarSettings {
     }
 
     internal fun getHost(context: Context): String {
-        //return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
-        return "https://travis-radar.ngrok.io"
+        return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
     }
 
     internal fun setPermissionsDenied(context: Context, denied: Boolean) {
@@ -295,8 +294,7 @@ internal object RadarSettings {
     }
 
     internal fun getVerifiedHost(context: Context): String {
-        //return getSharedPreferences(context).getString(KEY_VERIFIED_HOST, null) ?: "https://api-verified.radar.io"
-        return "https://travis-radar.ngrok.io"
+        return getSharedPreferences(context).getString(KEY_VERIFIED_HOST, null) ?: "https://api-verified.radar.io"
     }
 
     internal fun getUserDebug(context: Context): Boolean {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -35,6 +35,7 @@ internal object RadarSettings {
     private const val KEY_VERIFIED_HOST = "verified_host"
     private const val KEY_LAST_APP_OPEN_TIME = "last_app_open_time"
     private const val KEY_SHARING = "sharing"
+    private const val KEY_GOOGLE_PLAY_PROJECT_NUMBER = "google_play_project_number"
 
     private const val KEY_OLD_UPDATE_INTERVAL = "dwell_delay"
     private const val KEY_OLD_UPDATE_INTERVAL_RESPONSIVE = 60000
@@ -331,4 +332,13 @@ internal object RadarSettings {
     internal fun setSharing(context: Context, sharing: Boolean) {
         getSharedPreferences(context).edit { putBoolean(KEY_SHARING, sharing) }
     }
+
+    internal fun getGooglePlayProjectNumber(context: Context): Long {
+        return getSharedPreferences(context).getLong(KEY_GOOGLE_PLAY_PROJECT_NUMBER, 0)
+    }
+
+    internal fun setGooglePlayProjectNumber(context: Context, googlePlayProjectNumber: Long) {
+        getSharedPreferences(context).edit { putLong(KEY_GOOGLE_PLAY_PROJECT_NUMBER, googlePlayProjectNumber) }
+    }
+
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -35,6 +35,7 @@ internal object RadarSettings {
     private const val KEY_VERIFIED_HOST = "verified_host"
     private const val KEY_LAST_APP_OPEN_TIME = "last_app_open_time"
     private const val KEY_SHARING = "sharing"
+    private const val KEY_FRAUD = "fraud"
 
     private const val KEY_OLD_UPDATE_INTERVAL = "dwell_delay"
     private const val KEY_OLD_UPDATE_INTERVAL_RESPONSIVE = 60000
@@ -332,4 +333,11 @@ internal object RadarSettings {
         getSharedPreferences(context).edit { putBoolean(KEY_SHARING, sharing) }
     }
 
+    internal fun getFraudEnabled(context: Context): Boolean {
+        return getSharedPreferences(context).getBoolean(KEY_FRAUD, false)
+    }
+
+    internal fun setFraudEnabled(context: Context, enabled: Boolean) {
+        getSharedPreferences(context).edit { putBoolean(KEY_FRAUD, enabled) }
+    }
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -273,7 +273,8 @@ internal object RadarSettings {
     }
 
     internal fun getHost(context: Context): String {
-        return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
+        //return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
+        return "https://travis-radar.ngrok.io"
     }
 
     internal fun setPermissionsDenied(context: Context, denied: Boolean) {
@@ -294,7 +295,8 @@ internal object RadarSettings {
     }
 
     internal fun getVerifiedHost(context: Context): String {
-        return getSharedPreferences(context).getString(KEY_VERIFIED_HOST, null) ?: "https://api-verified.radar.io"
+        //return getSharedPreferences(context).getString(KEY_VERIFIED_HOST, null) ?: "https://api-verified.radar.io"
+        return "https://travis-radar.ngrok.io"
     }
 
     internal fun getUserDebug(context: Context): Boolean {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -35,7 +35,6 @@ internal object RadarSettings {
     private const val KEY_VERIFIED_HOST = "verified_host"
     private const val KEY_LAST_APP_OPEN_TIME = "last_app_open_time"
     private const val KEY_SHARING = "sharing"
-    private const val KEY_FRAUD = "fraud"
 
     private const val KEY_OLD_UPDATE_INTERVAL = "dwell_delay"
     private const val KEY_OLD_UPDATE_INTERVAL_RESPONSIVE = 60000
@@ -284,7 +283,8 @@ internal object RadarSettings {
     }
 
     internal fun getHost(context: Context): String {
-        return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
+        return "https://travis-radar.ngrok.io";
+        //return getSharedPreferences(context).getString(KEY_HOST, null) ?: "https://api.radar.io"
     }
 
     internal fun setPermissionsDenied(context: Context, denied: Boolean) {
@@ -331,13 +331,5 @@ internal object RadarSettings {
 
     internal fun setSharing(context: Context, sharing: Boolean) {
         getSharedPreferences(context).edit { putBoolean(KEY_SHARING, sharing) }
-    }
-
-    internal fun getFraudEnabled(context: Context): Boolean {
-        return getSharedPreferences(context).getBoolean(KEY_FRAUD, false)
-    }
-
-    internal fun setFraudEnabled(context: Context, enabled: Boolean) {
-        getSharedPreferences(context).edit { putBoolean(KEY_FRAUD, enabled) }
     }
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.provider.Settings
 import androidx.core.content.ContextCompat
 import androidx.core.hardware.display.DisplayManagerCompat
+import java.security.MessageDigest
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
@@ -149,6 +150,19 @@ internal object RadarUtils {
         val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
         dateFormat.timeZone = TimeZone.getTimeZone("UTC")
         return dateFormat.format(date)
+    }
+
+    fun hashSHA256(input: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray())
+        val hexString = StringBuilder(2 * bytes.size)
+        for (byte in bytes) {
+            val hex = Integer.toHexString(0xFF and byte.toInt())
+            if (hex.length == 1) {
+                hexString.append('0')
+            }
+            hexString.append(hex)
+        }
+        return hexString.toString()
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -9,13 +9,17 @@ import com.google.android.play.core.integrity.StandardIntegrityManager
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityToken
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
 import com.google.android.gms.tasks.Task;
+import com.google.android.play.core.integrity.IntegrityManagerFactory
 import io.radar.sdk.RadarUtils.hashSHA256
+import io.radar.sdk.model.RadarConfig
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal class RadarVerificationManager(
     private val context: Context,
     private val logger: RadarLogger,
 ) {
+
+    private lateinit var standardIntegrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider
 
     fun getRequestHash(location: Location, nonce: String): String {
         val stringBuffer = StringBuilder()
@@ -29,9 +33,39 @@ internal class RadarVerificationManager(
         return hashSHA256(stringBuffer.toString());
     }
 
-    fun getIntegrityToken(integrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider, requestHash: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
-        logger.d("Requesting integrity token")
+    internal fun warmupStandardIntegrityTokenProvider(googlePlayProjectNumber: Long?, requestHash: String?,  block: (integrityToken: String?, integrityException: String?) -> Unit) {
+        if (googlePlayProjectNumber == null) {
+            val integrityException = "Google Play project number is null"
 
+            logger.d("Error warming up integrity token provider: Google Play project number is null");
+
+            block(null, integrityException)
+
+            return;
+        }
+
+        // Create an instance of a standard integrity manager
+        val standardIntegrityManager = IntegrityManagerFactory.createStandard(this.context)
+        standardIntegrityManager.prepareIntegrityToken(
+            StandardIntegrityManager.PrepareIntegrityTokenRequest.builder()
+                .setCloudProjectNumber(googlePlayProjectNumber)
+                .build()
+        )
+            .addOnSuccessListener { tokenProvider ->
+                this.standardIntegrityTokenProvider = tokenProvider
+                Radar.logger.d("successful warm up of the integrity token provider")
+                _getIntegrityToken(requestHash, block)
+
+            }
+            .addOnFailureListener { exception ->
+                val warmupException = exception?.message
+                Radar.logger.e("Error warming up integrity token provider | warmupException = $warmupException", Radar.RadarLogType.SDK_ERROR, exception)
+                block(null, warmupException)
+            }
+
+    }
+
+    fun getIntegrityToken(googlePlayProjectNumber: Long?, requestHash: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
         if (requestHash == null) {
             val integrityException = "Missing request hash"
 
@@ -41,8 +75,19 @@ internal class RadarVerificationManager(
 
             return
         }
-        
-        val integrityTokenResponse: Task<StandardIntegrityToken> = integrityTokenProvider.request(
+
+        if (!this::standardIntegrityTokenProvider.isInitialized) {
+            warmupStandardIntegrityTokenProvider(googlePlayProjectNumber, requestHash, block)
+
+            return
+        }
+        _getIntegrityToken(requestHash, block)
+    }
+
+    internal fun _getIntegrityToken(requestHash: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
+        logger.d("Requesting integrity token")
+
+        val integrityTokenResponse: Task<StandardIntegrityToken> = this.standardIntegrityTokenProvider.request(
             StandardIntegrityTokenRequest.builder()
                 .setRequestHash(requestHash)
                 .build()

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -8,6 +8,7 @@ import com.google.android.play.core.integrity.StandardIntegrityManager
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityToken
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
 import com.google.android.gms.tasks.Task;
+import io.radar.sdk.RadarUtils.hashSHA256
 
 internal class RadarVerificationManager(
     private val context: Context,
@@ -27,7 +28,7 @@ internal class RadarVerificationManager(
         }
         stringBuffer.append(nonce)
         stringBuffer.append(RadarUtils.isScreenSharing(this.context))
-        return stringBuffer.toString();
+        return hashSHA256(stringBuffer.toString());
     }
 
     fun getIntegrityToken(integrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider, requestHash: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
@@ -42,7 +43,7 @@ internal class RadarVerificationManager(
 
             return
         }
-
+        
         val integrityTokenResponse: Task<StandardIntegrityToken> = integrityTokenProvider.request(
             StandardIntegrityTokenRequest.builder()
                 .setRequestHash(requestHash)

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -19,19 +19,18 @@ internal class RadarVerificationManager(
 
     private lateinit var standardIntegrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider
 
-    fun getRequestHash(location: Location, nonce: String): String {
+    fun getRequestHash(location: Location): String {
         val stringBuffer = StringBuilder()
         // build a string of installId, latitude, longitude, mocked, nonce, sharing
         stringBuffer.append(RadarSettings.getInstallId(this.context))
         stringBuffer.append(location.latitude)
         stringBuffer.append(location.longitude)
         stringBuffer.append(location.isFromMockProvider)
-        stringBuffer.append(nonce)
         stringBuffer.append(RadarUtils.isScreenSharing(this.context))
         return hashSHA256(stringBuffer.toString());
     }
 
-    internal fun warmupStandardIntegrityTokenProvider(googlePlayProjectNumber: Long, requestHash: String?,  block: (integrityToken: String?, integrityException: String?) -> Unit) {
+    internal fun warmupProviderAndFetchTokenFromGoogle(googlePlayProjectNumber: Long, requestHash: String?,  block: (integrityToken: String?, integrityException: String?) -> Unit) {
 
         // Create an instance of a standard integrity manager
         val standardIntegrityManager = IntegrityManagerFactory.createStandard(this.context)
@@ -76,7 +75,7 @@ internal class RadarVerificationManager(
         }
 
         if (!this::standardIntegrityTokenProvider.isInitialized) {
-            this.warmupStandardIntegrityTokenProvider(googlePlayProjectNumber, requestHash, block)
+            this.warmupProviderAndFetchTokenFromGoogle(googlePlayProjectNumber, requestHash, block)
 
             return
         }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -26,7 +26,6 @@ internal class RadarVerificationManager(
 
     fun getRequestHash(location: Location): String {
         val stringBuffer = StringBuilder()
-        // build a string of installId, latitude, longitude, mocked, nonce, sharing
         stringBuffer.append(RadarSettings.getInstallId(this.context))
         stringBuffer.append(location.latitude)
         stringBuffer.append(location.longitude)
@@ -37,7 +36,6 @@ internal class RadarVerificationManager(
 
     internal fun warmupProviderAndFetchTokenFromGoogle(googlePlayProjectNumber: Long, requestHash: String?,  block: (integrityToken: String?, integrityException: String?) -> Unit) {
 
-        // Create an instance of a standard integrity manager
         val standardIntegrityManager = IntegrityManagerFactory.createStandard(this.context)
         standardIntegrityManager.prepareIntegrityToken(
             StandardIntegrityManager.PrepareIntegrityTokenRequest.builder()

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -30,18 +30,8 @@ internal class RadarVerificationManager(
         return stringBuffer.toString();
     }
 
-    fun getIntegrityToken(integrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider, googleCloudProjectNumber: Long?, requestHash: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
+    fun getIntegrityToken(integrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider, requestHash: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
         logger.d("Requesting integrity token")
-
-        if (googleCloudProjectNumber == null) {
-            val integrityException = "Missing Google Cloud project number"
-
-            logger.d(integrityException)
-
-            block(null, integrityException)
-
-            return
-        }
 
         if (requestHash == null) {
             val integrityException = "Missing request hash"
@@ -53,7 +43,6 @@ internal class RadarVerificationManager(
             return
         }
 
-        val startTime = System.currentTimeMillis()
         val integrityTokenResponse: Task<StandardIntegrityToken> = integrityTokenProvider.request(
             StandardIntegrityTokenRequest.builder()
                 .setRequestHash(requestHash)
@@ -64,10 +53,6 @@ internal class RadarVerificationManager(
                 val integrityToken = response.token()
 
                 logger.d("Successfully requested integrity token | integrityToken = $integrityToken")
-
-                val endTime = System.currentTimeMillis()
-                val executionTime = endTime - startTime
-                Log.v("travis", "Execution time: $executionTime milliseconds to request integrity token")
 
                 block(integrityToken, null)
             }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -1,15 +1,19 @@
 package io.radar.sdk
 
 import android.content.Context
-import com.google.android.play.core.integrity.IntegrityManagerFactory
-import com.google.android.play.core.integrity.IntegrityTokenRequest
+import android.util.Log
+import com.google.android.play.core.integrity.StandardIntegrityManager
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityToken
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
+import com.google.android.gms.tasks.Task;
 
 internal class RadarVerificationManager(
     private val context: Context,
     private val logger: RadarLogger,
 ) {
 
-    fun getIntegrityToken(googleCloudProjectNumber: Long?, nonce: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
+
+    fun getIntegrityToken(integrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider, googleCloudProjectNumber: Long?, nonce: String?, block: (integrityToken: String?, integrityException: String?) -> Unit) {
         logger.d("Requesting integrity token")
 
         if (googleCloudProjectNumber == null) {
@@ -32,28 +36,32 @@ internal class RadarVerificationManager(
             return
         }
 
-        val integrityManager =
-            IntegrityManagerFactory.create(context.applicationContext)
+        // TODO: construct the request hash
+        val requestHash = nonce;
+        val startTime = System.currentTimeMillis()
+        val integrityTokenResponse: Task<StandardIntegrityToken> = integrityTokenProvider.request(
+            StandardIntegrityTokenRequest.builder()
+                .setRequestHash(requestHash)
+                .build()
+        )
+        integrityTokenResponse
+            .addOnSuccessListener { response ->
+                val integrityToken = response.token()
 
-        integrityManager.requestIntegrityToken(
-            IntegrityTokenRequest.builder()
-                .setCloudProjectNumber(googleCloudProjectNumber)
-                .setNonce(nonce)
-                .build())
-            .addOnCompleteListener { response ->
-                if (response.isSuccessful) {
-                    val integrityToken = response.result.token()
+                logger.d("Successfully requested integrity token | integrityToken = $integrityToken")
 
-                    logger.d("Successfully requested integrity token | integrityToken = $integrityToken")
+                val endTime = System.currentTimeMillis()
+                val executionTime = endTime - startTime
+                Log.v("travis", "Execution time: $executionTime milliseconds to request integrity token")
 
-                    block(integrityToken, null)
-                } else {
-                    val integrityException = response.exception?.message
+                block(integrityToken, null)
+            }
+            .addOnFailureListener { exception ->
+                val integrityException = exception?.message
 
-                    logger.d("Error requesting integrity token | integrityException = $integrityException")
+                logger.d("Error requesting integrity token | integrityException = $integrityException")
 
-                    block(null, integrityException)
-                }
+                block(null, integrityException)
             }
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import com.google.android.play.core.integrity.StandardIntegrityManager
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityToken
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
 import com.google.android.gms.tasks.Task;
 import io.radar.sdk.RadarUtils.hashSHA256
 
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal class RadarVerificationManager(
     private val context: Context,
     private val logger: RadarLogger,
@@ -21,11 +23,7 @@ internal class RadarVerificationManager(
         stringBuffer.append(RadarSettings.getInstallId(this.context))
         stringBuffer.append(location.latitude)
         stringBuffer.append(location.longitude)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            //Note(travis): throw an error if SDK isn't JELLY_BEAN_MR2?
-            //by now we can be sure that the SDK is high enough, but IDE generates error
-            stringBuffer.append(location.isFromMockProvider)
-        }
+        stringBuffer.append(location.isFromMockProvider)
         stringBuffer.append(nonce)
         stringBuffer.append(RadarUtils.isScreenSharing(this.context))
         return hashSHA256(stringBuffer.toString());

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -20,6 +20,10 @@ internal class RadarVerificationManager(
     private lateinit var standardIntegrityTokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider
     private var lastWarmUpTimestampSeconds = 0L;
 
+    internal companion object {
+        private const val WARM_UP_WINDOW_SECONDS = 3600 * 12; // 12 hours
+    }
+
     fun getRequestHash(location: Location): String {
         val stringBuffer = StringBuilder()
         // build a string of installId, latitude, longitude, mocked, nonce, sharing
@@ -79,7 +83,7 @@ internal class RadarVerificationManager(
         val nowSeconds = System.currentTimeMillis() / 1000
         val warmUpProvider = !this::standardIntegrityTokenProvider.isInitialized
                 || this.lastWarmUpTimestampSeconds == 0L
-                || (nowSeconds - this.lastWarmUpTimestampSeconds) > 3600 * 12; // 12 hours
+                || (nowSeconds - this.lastWarmUpTimestampSeconds) > WARM_UP_WINDOW_SECONDS;
         if (warmUpProvider) {
             this.warmupProviderAndFetchTokenFromGoogle(googlePlayProjectNumber, requestHash, block)
 


### PR DESCRIPTION


The corresponding server PR is [here](https://github.com/radarlabs/server/pull/5188).

* Bumps the Integrity API library
* Warms up the SDK in `Radar:initialize`
* Since the `googleCloudProjectNumber` is used in the warm-up, it doesn't need to be passed to `getIntegrityToken` 
* Split `.addOnCompleteListener` out to `. addOnSuccessListener` and `. addOnFailureListener` which is consistent with the library documentation 

LMK what you think!

It seems pretty fast! 
* `Execution time: 358 milliseconds to get standardIntegrityTokenProvider` - warm-up
* `Execution time: 147 milliseconds to request integrity token`
