### PR TITLE
track once to modify tracking options

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.11'
+    radarVersion = '3.8.11-beta.4'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.11-beta.4'
+    radarVersion = '3.8.12'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -810,7 +810,6 @@ object Radar {
                             handler.post {
                                 callback?.onComplete(status, location, events, user)
                             }
-
                         }
                     })
                 }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -804,9 +804,11 @@ object Radar {
                             config: RadarConfig?,
                             token: String?
                         ) {
+                            locationManager.updateTrackingFromMeta(config?.meta)
                             handler.post {
                                 callback?.onComplete(status, location, events, user)
                             }
+
                         }
                     })
                 }
@@ -898,6 +900,7 @@ object Radar {
                 config: RadarConfig?,
                 token: String?
             ) {
+                locationManager.updateTrackingFromMeta(config?.meta)
                 handler.post {
                     callback?.onComplete(status, location, events, user)
                 }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -807,7 +807,6 @@ object Radar {
                             if (status == RadarStatus.SUCCESS ){
                                 locationManager.updateTrackingFromMeta(config?.meta)
                             }
-
                             handler.post {
                                 callback?.onComplete(status, location, events, user)
                             }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -804,7 +804,10 @@ object Radar {
                             config: RadarConfig?,
                             token: String?
                         ) {
-                            locationManager.updateTrackingFromMeta(config?.meta)
+                            if (status == RadarStatus.SUCCESS ){
+                                locationManager.updateTrackingFromMeta(config?.meta)
+                            }
+
                             handler.post {
                                 callback?.onComplete(status, location, events, user)
                             }
@@ -900,7 +903,9 @@ object Radar {
                 config: RadarConfig?,
                 token: String?
             ) {
-                locationManager.updateTrackingFromMeta(config?.meta)
+                if (status == RadarStatus.SUCCESS ){
+                    locationManager.updateTrackingFromMeta(config?.meta)
+                }
                 handler.post {
                     callback?.onComplete(status, location, events, user)
                 }
@@ -970,6 +975,9 @@ object Radar {
                                     config: RadarConfig?,
                                     token: String?
                                 ) {
+                                    if (status == RadarStatus.SUCCESS ){
+                                        locationManager.updateTrackingFromMeta(config?.meta)
+                                    }
                                     handler.post {
                                         callback?.onComplete(status, location, events, user)
                                     }
@@ -1045,6 +1053,9 @@ object Radar {
                                     config: RadarConfig?,
                                     token: String?
                                 ) {
+                                    if (status == RadarStatus.SUCCESS ){
+                                        locationManager.updateTrackingFromMeta(config?.meta)
+                                    }
                                     handler.post {
                                         callback?.onComplete(status, token)
                                     }


### PR DESCRIPTION
Including side-effect of track once calls such that if the SDK's RTO are not in sync with the project's server side RTO, SDK will update its own RTO setting

QA:
steps: 

1. Have RTO turned off
2. check that RTO is not on in waypoint setting: 
<img width="385" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/571e51e4-184c-4287-a6bd-6f7651a7b4ff">

3. turn on RTO to efficient in dashboard
4. call track once in waypoint and verify that it updated
<img width="395" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/1ad8a9d0-dcfd-4cb8-bd94-194cdb4016a8">

5. modify RTO settings on dashboard and verify that it is propagated to waypoint after a calling trackOnce
<img width="402" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/8e35cfab-f696-49fc-9784-cff52919c4a6">

6. turn off RTO on dashboard and call another trackonce on waypoint to verify that RTO is turned off
<img width="393" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/5135e791-3437-45ab-a907-35a57349bc72">

Follow up question, do we wish to introduce this side effect to the track verified calls and the mock tracking calls too?