### PR TITLE
Expose versioning

### DIFF
--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : AppCompatActivity() {
 
         val receiver = MyRadarReceiver()
         Radar.initialize(this, "prj_test_pk_0000000000000000000000000000000000000000", receiver, Radar.RadarLocationServicesProvider.GOOGLE, true)
-
+        Radar.sdkVersion()?.let { Log.i("version", it) }
         requestLocationPermissionLauncher = registerForActivityResult(
             ActivityResultContracts.RequestMultiplePermissions()
         ) { isGrantedMap ->

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3263,6 +3263,19 @@ object Radar {
         return obj
     }
 
+    /**
+     * Gets the version number of the Radar SDK, such as "3.5.1" or "3.5.1-beta.2".
+     *
+     * @return The current `sdkVersion`.
+    */
+    @JvmStatic
+    fun sdkVersion() : String?{
+
+        return RadarUtils.sdkVersion
+
+    }
+
+
     internal fun handleLocation(context: Context, location: Location, source: RadarLocationSource) {
         if (!initialized) {
             initialize(context)

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3269,7 +3269,7 @@ object Radar {
      * @return The current `sdkVersion`.
     */
     @JvmStatic
-    fun sdkVersion() : String?{
+    fun sdkVersion() : String{
 
         return RadarUtils.sdkVersion
 


### PR DESCRIPTION
This PR creates an endpoint that returns the string of the versioning of the sdk for parity with the IOS sdk.

the interface of the PR is 
`fun sdkVersion() : String`

QA:
Tested in example app to log versioning after initialization and was was successful.

<img width="1124" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/09357d31-8b57-4e61-812c-0eca4aeb75f0">


 