### PR TITLE
Fix for set foreground service options icon

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.13'
+    radarVersion = '3.8.14'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -55,9 +55,10 @@ class RadarForegroundService : Service() {
         importance = if (importance == 0) NotificationManager.IMPORTANCE_DEFAULT else importance
         val title = extras?.getString("title")
         val text = extras?.getString("text") ?: "Location tracking started"
-        var icon = extras?.getInt("icon") ?: 0
+        var icon = extras?.getString("icon") ?: 0
         icon = if (icon == 0) this.applicationInfo.icon else icon
-        val smallIcon = resources.getIdentifier(icon.toString(), "drawable", applicationContext.packageName)
+        var iconString = extras?.getInt("iconString") ?: this.applicationInfo.icon.toString()
+        val smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName)
         val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: "Location Services"
         val channel = NotificationChannel("RadarSDK", channelName, importance)
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -55,7 +55,7 @@ class RadarForegroundService : Service() {
         importance = if (importance == 0) NotificationManager.IMPORTANCE_DEFAULT else importance
         val title = extras?.getString("title")
         val text = extras?.getString("text") ?: "Location tracking started"
-        var icon = extras?.getString("icon") ?: 0
+        var icon = extras?.getInt("icon") ?: 0
         icon = if (icon == 0) this.applicationInfo.icon else icon
         var iconString = extras?.getString("iconString") ?: this.applicationInfo.icon.toString()
         val smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName)

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -56,9 +56,11 @@ class RadarForegroundService : Service() {
         val title = extras?.getString("title")
         val text = extras?.getString("text") ?: "Location tracking started"
         var icon = extras?.getInt("icon") ?: 0
-        icon = if (icon == 0) this.applicationInfo.icon else icon
         var iconString = extras?.getString("iconString") ?: this.applicationInfo.icon.toString()
-        val smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName)
+        val smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName) 
+        if (icon != 0){
+           smallIcon = resources.getIdentifier(icon.toString(), "drawable", applicationContext.packageName)  
+        }
         val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: "Location Services"
         val channel = NotificationChannel("RadarSDK", channelName, importance)
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -57,7 +57,7 @@ class RadarForegroundService : Service() {
         val text = extras?.getString("text") ?: "Location tracking started"
         var icon = extras?.getString("icon") ?: 0
         icon = if (icon == 0) this.applicationInfo.icon else icon
-        var iconString = extras?.getInt("iconString") ?: this.applicationInfo.icon.toString()
+        var iconString = extras?.getString("iconString") ?: this.applicationInfo.icon.toString()
         val smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName)
         val channelName = extras?.getString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME) ?: "Location Services"
         val channel = NotificationChannel("RadarSDK", channelName, importance)

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -57,7 +57,7 @@ class RadarForegroundService : Service() {
         val text = extras?.getString("text") ?: "Location tracking started"
         var icon = extras?.getInt("icon") ?: 0
         var iconString = extras?.getString("iconString") ?: this.applicationInfo.icon.toString()
-        val smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName) 
+        var smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName) 
         if (icon != 0){
            smallIcon = resources.getIdentifier(icon.toString(), "drawable", applicationContext.packageName)  
         }

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -654,6 +654,7 @@ internal class RadarLocationManager(
                         .putExtra("title", foregroundService.title)
                         .putExtra("text", foregroundService.text)
                         .putExtra("icon", foregroundService.icon)
+                        .putExtra("iconString", foregroundService.iconString)
                         .putExtra("activity", foregroundService.activity)
                     logger.d("Starting foreground service with intent | intent = $intent")
                     context.applicationContext.startForegroundService(intent)

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -265,11 +265,6 @@ data class RadarTrackingOptions(
         val icon: Int? = null,
 
         /**
-         * Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
-         */
-        val iconString: String? = null,
-
-        /**
          * Determines when to show the notification. Use `false` to show the notification always, use `true` to show the notification only during location updates. Optional, defaults to `false`.
          */
         val updatesOnly: Boolean = false,
@@ -293,7 +288,12 @@ data class RadarTrackingOptions(
          * Determines the user-facing channel name, which can be viewed in notification settings for the application.
          * Optional, defaults to `"Location Services"`.
          */
-        val channelName: String? = null
+        val channelName: String? = null,
+
+        /**
+         * Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
+         */
+        val iconString: String? = null,
     ) {
 
         companion object {
@@ -323,7 +323,7 @@ data class RadarTrackingOptions(
                 val id = if (obj.isNull(KEY_FOREGROUND_SERVICE_ID)) null else obj.optInt(KEY_FOREGROUND_SERVICE_ID)
                 val channelName = if (obj.isNull(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)) null else obj.optString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)
 
-                return RadarTrackingOptionsForegroundService(text, title, icon, iconString, updatesOnly, activity, importance, id, channelName)
+                return RadarTrackingOptionsForegroundService(text, title, icon, updatesOnly, activity, importance, id, channelName, iconString)
             }
         }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -333,6 +333,7 @@ data class RadarTrackingOptions(
             obj.put(KEY_FOREGROUND_SERVICE_TEXT, text)
             obj.put(KEY_FOREGROUND_SERVICE_TITLE, title)
             obj.put(KEY_FOREGROUND_SERVICE_ICON, icon)
+            obj.put(KEY_FOREGROUND_SERVICE_ICON_STRING, iconString) 
             obj.put(KEY_FOREGROUND_SERVICE_ACTIVITY, activity)
             obj.put(KEY_FOREGROUND_SERVICE_UPDATES_ONLY, updatesOnly)
             obj.put(KEY_FOREGROUND_SERVICE_IMPORTANCE, importance)

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -265,6 +265,11 @@ data class RadarTrackingOptions(
         val icon: Int? = null,
 
         /**
+         * Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
+         */
+        val iconString: String? = null,
+
+        /**
          * Determines when to show the notification. Use `false` to show the notification always, use `true` to show the notification only during location updates. Optional, defaults to `false`.
          */
         val updatesOnly: Boolean = false,
@@ -295,6 +300,7 @@ data class RadarTrackingOptions(
             internal const val KEY_FOREGROUND_SERVICE_TEXT = "text"
             internal const val KEY_FOREGROUND_SERVICE_TITLE = "title"
             internal const val KEY_FOREGROUND_SERVICE_ICON = "icon"
+            internal const val KEY_FOREGROUND_SERVICE_ICON_STRING = "iconString"
             internal const val KEY_FOREGROUND_SERVICE_UPDATES_ONLY = "updatesOnly"
             internal const val KEY_FOREGROUND_SERVICE_ACTIVITY = "activity"
             internal const val KEY_FOREGROUND_SERVICE_IMPORTANCE = "importance"
@@ -310,13 +316,14 @@ data class RadarTrackingOptions(
                 val text = if (obj.isNull(KEY_FOREGROUND_SERVICE_TEXT)) null else obj.optString(KEY_FOREGROUND_SERVICE_TEXT)
                 val title = if (obj.isNull(KEY_FOREGROUND_SERVICE_TITLE)) null else obj.optString(KEY_FOREGROUND_SERVICE_TITLE)
                 val icon = if (obj.isNull(KEY_FOREGROUND_SERVICE_ICON)) null else obj.optInt(KEY_FOREGROUND_SERVICE_ICON)
+                val iconString = if (obj.isNull(KEY_FOREGROUND_SERVICE_ICON_STRING)) null else obj.optString(KEY_FOREGROUND_SERVICE_ICON_STRING)
                 val updatesOnly: Boolean = obj.optBoolean(KEY_FOREGROUND_SERVICE_UPDATES_ONLY)
                 val activity = if (obj.isNull(KEY_FOREGROUND_SERVICE_ACTIVITY)) null else obj.optString(KEY_FOREGROUND_SERVICE_ACTIVITY)
                 val importance = if (obj.isNull(KEY_FOREGROUND_SERVICE_IMPORTANCE)) null else obj.optInt(KEY_FOREGROUND_SERVICE_IMPORTANCE)
                 val id = if (obj.isNull(KEY_FOREGROUND_SERVICE_ID)) null else obj.optInt(KEY_FOREGROUND_SERVICE_ID)
                 val channelName = if (obj.isNull(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)) null else obj.optString(KEY_FOREGROUND_SERVICE_CHANNEL_NAME)
 
-                return RadarTrackingOptionsForegroundService(text, title, icon, updatesOnly, activity, importance, id, channelName)
+                return RadarTrackingOptionsForegroundService(text, title, icon, iconString, updatesOnly, activity, importance, id, channelName)
             }
         }
 

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -535,7 +535,7 @@ class RadarTest {
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
             "Text",
             "Title",
-            123,
+            1337,
             true
         ))
 

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -536,6 +536,7 @@ class RadarTest {
             "Text",
             "Title",
             1337,
+            "",
             true
         ))
 

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -535,8 +535,7 @@ class RadarTest {
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
             "Text",
             "Title",
-            1337,
-            "",
+            123,
             true
         ))
 


### PR DESCRIPTION
We are adding a new field, `iconString` to the fields expected by the `setForgroundOptions` function. This allows the user to set the name of the asset they wish to use in the notification.
QA: 
The icon was changed to a bluetooth sign on waypoint
<img width="164" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/0a43bfb2-c7e1-43c5-9580-f3b1ef3213ca">
