### PR TITLE
setNotificationsOptions end point

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.15'
+    radarVersion = '3.8.15-localtest'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.15-localtest'
+    radarVersion = '3.8.16'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1336,7 +1336,7 @@ object Radar {
     }
 
     /**
-     * Settings for the all notification.
+     * Settings for the all notifications.
      *
      * @see [](https://radar.com/documentation/sdk)
      *

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1336,6 +1336,23 @@ object Radar {
     }
 
     /**
+     * Settings for the all notification.
+     *
+     * @see [](https://radar.com/documentation/sdk)
+     *
+     * @param[options] Notifications options
+     */
+    @JvmStatic
+    fun setNotificationsOptions(options: RadarNotificationsOptions) {
+        if (!initialized) {
+            return
+        }
+
+        RadarSettings.setNotificationsOptions(context, options)
+    }
+
+
+    /**
      * Sets a receiver for client-side delivery of events, location updates, and debug logs.
      *
      * @see [](https://radar.com/documentation/sdk/android#listening-for-events-with-a-receiver)

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1343,12 +1343,12 @@ object Radar {
      * @param[options] Notifications options
      */
     @JvmStatic
-    fun setNotificationsOptions(options: RadarNotificationsOptions) {
+    fun setNotificationOptions(options: RadarNotificationOptions) {
         if (!initialized) {
             return
         }
 
-        RadarSettings.setNotificationsOptions(context, options)
+        RadarSettings.setNotificationOptions(context, options)
     }
 
 

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
@@ -50,12 +50,10 @@ class RadarNotificationHelper {
                     channel.enableVibration(true)
                     notificationManager?.createNotificationChannel(channel)
 
-                    val foregroundServiceOptions = RadarSettings.getForegroundService(context);
-
                     val notificationOptions = RadarSettings.getNotificationOptions(context);
 
-                    var iconString = notificationOptions?.getEventIcon()?: context.applicationContext.applicationInfo.icon.toString()
-                    var smallIcon = context.applicationContext.resources.getIdentifier(iconString, "drawable", context.applicationContext.packageName)
+                    val iconString = notificationOptions?.getEventIcon()?: context.applicationContext.applicationInfo.icon.toString()
+                    val smallIcon = context.applicationContext.resources.getIdentifier(iconString, "drawable", context.applicationContext.packageName)
 
                     val builder = NotificationCompat.Builder(context, CHANNEL_NAME)
                         .setSmallIcon(smallIcon)
@@ -64,7 +62,7 @@ class RadarNotificationHelper {
                         .setStyle(NotificationCompat.BigTextStyle().bigText(notificationText))
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
 
-                    var iconColor = notificationOptions?.getEventColor()?: ""
+                    val iconColor = notificationOptions?.getEventColor()?: ""
                     if (iconColor.isNotEmpty()) {
                         builder.setColor(Color.parseColor(iconColor))
                     }

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
@@ -9,6 +9,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import io.radar.sdk.model.RadarEvent
+import android.graphics.Color
 
 class RadarNotificationHelper {
 
@@ -49,15 +50,24 @@ class RadarNotificationHelper {
                     channel.enableVibration(true)
                     notificationManager?.createNotificationChannel(channel)
 
-                    val notification = NotificationCompat.Builder(context, CHANNEL_NAME)
-                        .setSmallIcon(context.applicationContext.applicationInfo.icon)
+                    val foregroundServiceOptions = RadarSettings.getForegroundService(context);
+
+                    var iconString = foregroundServiceOptions.iconString?: context.applicationContext.applicationInfo.icon.toString()
+                    var smallIcon = context.applicationContext.resources.getIdentifier(iconString, "drawable", context.applicationContext.packageName)
+
+                    val builder = NotificationCompat.Builder(context, CHANNEL_NAME)
+                        .setSmallIcon(smallIcon)
                         .setAutoCancel(true)
                         .setContentText(notificationText)
                         .setStyle(NotificationCompat.BigTextStyle().bigText(notificationText))
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                        .build()
 
-                    notificationManager?.notify(id, NOTIFICATION_ID, notification)
+                    var iconColor = foregroundServiceOptions.iconColor?: ""
+                    if (iconColor.isNotEmpty()) {
+                        builder.setColor(Color.parseColor(iconColor))
+                    }
+                    
+                    notificationManager?.notify(id, NOTIFICATION_ID, builder.build())
                 }
             }
         }

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
@@ -52,7 +52,9 @@ class RadarNotificationHelper {
 
                     val foregroundServiceOptions = RadarSettings.getForegroundService(context);
 
-                    var iconString = foregroundServiceOptions.iconString?: context.applicationContext.applicationInfo.icon.toString()
+                    val notificationOptions = RadarSettings.getNotificationOptions(context);
+
+                    var iconString = notificationOptions?.getEventIcon()?: context.applicationContext.applicationInfo.icon.toString()
                     var smallIcon = context.applicationContext.resources.getIdentifier(iconString, "drawable", context.applicationContext.packageName)
 
                     val builder = NotificationCompat.Builder(context, CHANNEL_NAME)
@@ -62,7 +64,7 @@ class RadarNotificationHelper {
                         .setStyle(NotificationCompat.BigTextStyle().bigText(notificationText))
                         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
 
-                    var iconColor = foregroundServiceOptions.iconColor?: ""
+                    var iconColor = notificationOptions?.getEventColor()?: ""
                     if (iconColor.isNotEmpty()) {
                         builder.setColor(Color.parseColor(iconColor))
                     }

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationOptions.kt
@@ -8,7 +8,7 @@ import java.util.Date
  *
  * @see [](https://radar.com/documentation/sdk/android)
  */
-data class RadarNotificationsOptions(
+data class RadarNotificationOptions(
     /**
      * Determines the name of the asset to be used for notifications. Optional, defaults to app icon.  
      */
@@ -53,7 +53,7 @@ data class RadarNotificationsOptions(
       
 
         @JvmStatic
-        fun fromJson(obj: JSONObject): RadarNotificationsOptions {
+        fun fromJson(obj: JSONObject): RadarNotificationOptions {
             val iconString = if (obj.isNull(KEY_ICON_STRING)) null else obj.optString(KEY_ICON_STRING)
             val iconColor = if (obj.isNull(KEY_ICON_COLOR)) null else obj.optString(KEY_ICON_COLOR)
             val foregroundServiceIconString = if (obj.isNull(KEY_FOREGROUNDSERVICE_ICON_STRING)) null else obj.optString(KEY_FOREGROUNDSERVICE_ICON_STRING)
@@ -61,7 +61,7 @@ data class RadarNotificationsOptions(
             val eventIconString = if (obj.isNull(KEY_EVENT_ICON_STRING)) null else obj.optString(KEY_EVENT_ICON_STRING)
             val eventIconColor = if (obj.isNull(KEY_EVENT_ICON_COLOR)) null else obj.optString(KEY_EVENT_ICON_COLOR)
 
-            return RadarNotificationsOptions(iconString,iconColor,foregroundServiceIconString,foregroundServiceIconColor,eventIconString,eventIconColor)
+            return RadarNotificationOptions(iconString,iconColor,foregroundServiceIconString,foregroundServiceIconColor,eventIconString,eventIconColor)
         }
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationOptions.kt
@@ -38,16 +38,14 @@ data class RadarNotificationOptions(
      * Determines the name of the asset to be used for event notifications. Optional, defaults to iconString.
      */
     val eventIconColor: String? = null,
-
-   
 ) {
 
     companion object {
 
-        internal const val KEY_ICON_STRING= "iconString"
-        internal const val KEY_ICON_COLOR= "iconColor"
-        internal const val KEY_FOREGROUNDSERVICE_ICON_STRING= "foregroundServiceIconString"
-        internal const val KEY_FOREGROUNDSERVICE_ICON_COLOR= "foregroundServiceIconColor"
+        internal const val KEY_ICON_STRING = "iconString"
+        internal const val KEY_ICON_COLOR = "iconColor"
+        internal const val KEY_FOREGROUNDSERVICE_ICON_STRING = "foregroundServiceIconString"
+        internal const val KEY_FOREGROUNDSERVICE_ICON_COLOR = "foregroundServiceIconColor"
         internal const val KEY_EVENT_ICON_STRING = "eventIconString"
         internal const val KEY_EVENT_ICON_COLOR = "eventIconColor"
       
@@ -61,7 +59,7 @@ data class RadarNotificationOptions(
             val eventIconString = if (obj.isNull(KEY_EVENT_ICON_STRING)) null else obj.optString(KEY_EVENT_ICON_STRING)
             val eventIconColor = if (obj.isNull(KEY_EVENT_ICON_COLOR)) null else obj.optString(KEY_EVENT_ICON_COLOR)
 
-            return RadarNotificationOptions(iconString,iconColor,foregroundServiceIconString,foregroundServiceIconColor,eventIconString,eventIconColor)
+            return RadarNotificationOptions(iconString, iconColor, foregroundServiceIconString, foregroundServiceIconColor, eventIconString, eventIconColor)
         }
     }
 
@@ -76,19 +74,19 @@ data class RadarNotificationOptions(
         return obj
     }
 
-    fun getForegroundServiceIcon():String?{
+    fun getForegroundServiceIcon(): String? {
         return foregroundServiceIconString ?: iconString
     }
 
-    fun getForegroundServiceColor():String?{
+    fun getForegroundServiceColor(): String? {
         return foregroundServiceIconColor ?: iconColor
     }
 
-    fun getEventIcon():String?{
+    fun getEventIcon(): String? {
         return eventIconString ?: iconString
     }
 
-    fun getEventColor():String?{
+    fun getEventColor(): String? {
         return eventIconColor ?: iconColor
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationsOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationsOptions.kt
@@ -1,0 +1,95 @@
+package io.radar.sdk
+
+import org.json.JSONObject
+import java.util.Date
+
+/**
+ * An options class used to configure local notifications.
+ *
+ * @see [](https://radar.com/documentation/sdk/android)
+ */
+data class RadarNotificationsOptions(
+    /**
+     * Determines the name of the asset to be used for notifications. Optional, defaults to app icon.  
+     */
+    val iconString: String? = null,
+
+    /**
+     * Determines the background color of used for notifications. Optional.
+     */
+    val iconColor: String? = null,
+
+    /**
+     * Determines the name of the asset to be used for forgroundService notifications. Optional, defaults to iconString.
+     */
+    var foregroundServiceIconString: String? = null,
+
+    /**
+     * Determines the name of the asset to be used for forgroundService notifications. Optional, defaults to iconString.
+     */
+    var foregroundServiceIconColor: String? = null,
+
+    /**
+     * Determines the name of the asset to be used for event notifications. Optional, defaults to iconString.
+     */
+    var eventIconString:String? = null,
+
+    /**
+     * Determines the name of the asset to be used for event notifications. Optional, defaults to iconString.
+     */
+    var eventIconColor: String? = null,
+
+   
+) {
+
+    companion object {
+
+        internal const val KEY_ICON_STRING= "iconString"
+        internal const val KEY_ICON_COLOR= "iconColor"
+        internal const val KEY_FOREGROUNDSERVICE_ICON_STRING= "foregroundServiceIconString"
+        internal const val KEY_FOREGROUNDSERVICE_ICON_COLOR= "foregroundServiceIconColor"
+        internal const val KEY_EVENT_ICON_STRING = "eventIconString"
+        internal const val KEY_EVENT_ICON_COLOR = "eventIconColor"
+      
+
+        @JvmStatic
+        fun fromJson(obj: JSONObject): RadarNotificationsOptions {
+            val iconString = if (obj.isNull(KEY_ICON_STRING)) null else obj.optString(KEY_ICON_STRING)
+            val iconColor = if (obj.isNull(KEY_ICON_COLOR)) null else obj.optString(KEY_ICON_COLOR)
+            val foregroundServiceIconString = if (obj.isNull(KEY_FOREGROUNDSERVICE_ICON_STRING)) null else obj.optString(KEY_FOREGROUNDSERVICE_ICON_STRING)
+            val foregroundServiceIconColor = if (obj.isNull(KEY_FOREGROUNDSERVICE_ICON_COLOR)) null else obj.optString(KEY_FOREGROUNDSERVICE_ICON_COLOR)
+            val eventIconString = if (obj.isNull(KEY_EVENT_ICON_STRING)) null else obj.optString(KEY_EVENT_ICON_STRING)
+            val eventIconColor = if (obj.isNull(KEY_EVENT_ICON_COLOR)) null else obj.optString(KEY_EVENT_ICON_COLOR)
+
+            return RadarNotificationsOptions(iconString,iconColor,foregroundServiceIconString,foregroundServiceIconColor,eventIconString,eventIconColor)
+        }
+    }
+
+    fun toJson(): JSONObject {
+        val obj = JSONObject()
+        obj.put(KEY_ICON_STRING, iconString)
+        obj.put(KEY_ICON_COLOR, iconColor)
+        obj.put(KEY_FOREGROUNDSERVICE_ICON_STRING, foregroundServiceIconString)
+        obj.put(KEY_FOREGROUNDSERVICE_ICON_COLOR, foregroundServiceIconColor)
+        obj.put(KEY_EVENT_ICON_STRING, eventIconString)
+        obj.put(KEY_EVENT_ICON_COLOR, eventIconColor)
+        return obj
+    }
+
+    fun getForegroundServiceIcon():String?{
+        return foregroundServiceIconString ?: iconString
+    }
+
+    fun getForegroundServiceColor():String?{
+        return foregroundServiceIconColor ?: iconColor
+    }
+
+    fun getEventIcon():String?{
+        return eventIconString ?: iconString
+    }
+
+    fun getEventColor():String?{
+        return eventIconColor ?: iconColor
+    }
+
+}

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationsOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationsOptions.kt
@@ -22,22 +22,22 @@ data class RadarNotificationsOptions(
     /**
      * Determines the name of the asset to be used for forgroundService notifications. Optional, defaults to iconString.
      */
-    var foregroundServiceIconString: String? = null,
+    val foregroundServiceIconString: String? = null,
 
     /**
      * Determines the name of the asset to be used for forgroundService notifications. Optional, defaults to iconString.
      */
-    var foregroundServiceIconColor: String? = null,
+    val foregroundServiceIconColor: String? = null,
 
     /**
      * Determines the name of the asset to be used for event notifications. Optional, defaults to iconString.
      */
-    var eventIconString:String? = null,
+    val eventIconString:String? = null,
 
     /**
      * Determines the name of the asset to be used for event notifications. Optional, defaults to iconString.
      */
-    var eventIconColor: String? = null,
+    val eventIconColor: String? = null,
 
    
 ) {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -26,7 +26,7 @@ internal object RadarSettings {
     private const val KEY_PREVIOUS_TRACKING_OPTIONS = "previous_tracking_options"
     private const val KEY_REMOTE_TRACKING_OPTIONS = "remote_tracking_options"
     private const val KEY_FOREGROUND_SERVICE = "foreground_service"
-    private const val KEY_NOTIFICATION_OPTIONS = "notificationOptions"
+    private const val KEY_NOTIFICATION_OPTIONS = "notification_options"
     private const val KEY_FEATURE_SETTINGS = "feature_settings"
     private const val KEY_TRIP_OPTIONS = "trip_options"
     private const val KEY_LOG_LEVEL = "log_level"

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -26,6 +26,7 @@ internal object RadarSettings {
     private const val KEY_PREVIOUS_TRACKING_OPTIONS = "previous_tracking_options"
     private const val KEY_REMOTE_TRACKING_OPTIONS = "remote_tracking_options"
     private const val KEY_FOREGROUND_SERVICE = "foreground_service"
+    private const val KEY_NOTIFICATION_OPTIONS = "notificationOptions"
     private const val KEY_FEATURE_SETTINGS = "feature_settings"
     private const val KEY_TRIP_OPTIONS = "trip_options"
     private const val KEY_LOG_LEVEL = "log_level"
@@ -226,6 +227,31 @@ internal object RadarSettings {
         getSharedPreferences(context).edit { remove(KEY_REMOTE_TRACKING_OPTIONS) }
     }
 
+    internal fun setNotificationsOptions(context:Context,notificationOptions:RadarNotificationsOptions){
+        val notificationOptionsJson = notificationOptions.toJson().toString()
+        getSharedPreferences(context).edit { putString(KEY_NOTIFICATION_OPTIONS, notificationOptionsJson) }
+        // Update foregroundServiceOptions as well.
+        var previousValue = getForegroundService(context)
+        setForegroundService(context,RadarTrackingOptions.RadarTrackingOptionsForegroundService(
+            previousValue.text,
+            previousValue.title,
+            previousValue.icon,
+            previousValue.updatesOnly,
+            previousValue.activity,
+            previousValue.importance,
+            previousValue.id,
+            previousValue.channelName,
+            notificationOptions.getForegroundServiceIcon()?:previousValue.iconString,
+            notificationOptions.getForegroundServiceColor()?:previousValue.iconColor
+        ))
+    }
+
+    internal fun getNotificationOptions(context: Context):RadarNotificationsOptions?{
+        val optionsJson = getSharedPreferences(context).getString(KEY_NOTIFICATION_OPTIONS, null) ?: return null
+        val optionsObj = JSONObject(optionsJson)
+        return RadarNotificationsOptions.fromJson(optionsObj)
+    }
+
     internal fun getForegroundService(context: Context): RadarTrackingOptions.RadarTrackingOptionsForegroundService {
         val foregroundJson = getSharedPreferences(context).getString(KEY_FOREGROUND_SERVICE, null)
         var foregroundService: RadarTrackingOptions.RadarTrackingOptionsForegroundService? = null
@@ -243,6 +269,14 @@ internal object RadarSettings {
         context: Context,
         foregroundService: RadarTrackingOptions.RadarTrackingOptionsForegroundService
     ) {
+        // Previous values of iconColor and iconString are preserved if those fields are not specified.
+        val previousValue = getForegroundService(context)
+        if(foregroundService.iconString == null){
+           foregroundService.iconString = previousValue.iconString 
+        }
+        if(foregroundService.iconColor == null){
+           foregroundService.iconColor = previousValue.iconColor 
+        }
         val foregroundJson = foregroundService.toJson().toString()
         getSharedPreferences(context).edit { putString(KEY_FOREGROUND_SERVICE, foregroundJson) }
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -269,7 +269,7 @@ internal object RadarSettings {
         context: Context,
         foregroundService: RadarTrackingOptions.RadarTrackingOptionsForegroundService
     ) {
-        // Previous values of iconColor and iconString are preserved if those fields are not specified.
+        // Previous values of iconColor and iconString are preserved if new fields are null.
         val previousValue = getForegroundService(context)
         if(foregroundService.iconString == null) {
            foregroundService.iconString = previousValue.iconString 

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -227,7 +227,7 @@ internal object RadarSettings {
         getSharedPreferences(context).edit { remove(KEY_REMOTE_TRACKING_OPTIONS) }
     }
 
-    internal fun setNotificationsOptions(context:Context,notificationOptions:RadarNotificationsOptions){
+    internal fun setNotificationOptions(context:Context,notificationOptions:RadarNotificationOptions){
         val notificationOptionsJson = notificationOptions.toJson().toString()
         getSharedPreferences(context).edit { putString(KEY_NOTIFICATION_OPTIONS, notificationOptionsJson) }
         // Update foregroundServiceOptions as well.
@@ -246,10 +246,10 @@ internal object RadarSettings {
         ))
     }
 
-    internal fun getNotificationOptions(context: Context):RadarNotificationsOptions?{
+    internal fun getNotificationOptions(context: Context):RadarNotificationOptions?{
         val optionsJson = getSharedPreferences(context).getString(KEY_NOTIFICATION_OPTIONS, null) ?: return null
         val optionsObj = JSONObject(optionsJson)
-        return RadarNotificationsOptions.fromJson(optionsObj)
+        return RadarNotificationOptions.fromJson(optionsObj)
     }
 
     internal fun getForegroundService(context: Context): RadarTrackingOptions.RadarTrackingOptionsForegroundService {
@@ -271,10 +271,10 @@ internal object RadarSettings {
     ) {
         // Previous values of iconColor and iconString are preserved if those fields are not specified.
         val previousValue = getForegroundService(context)
-        if(foregroundService.iconString == null){
+        if(foregroundService.iconString == null) {
            foregroundService.iconString = previousValue.iconString 
         }
-        if(foregroundService.iconColor == null){
+        if(foregroundService.iconColor == null) {
            foregroundService.iconColor = previousValue.iconColor 
         }
         val foregroundJson = foregroundService.toJson().toString()

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -271,10 +271,10 @@ internal object RadarSettings {
     ) {
         // Previous values of iconColor and iconString are preserved if new fields are null.
         val previousValue = getForegroundService(context)
-        if(foregroundService.iconString == null) {
+        if (foregroundService.iconString == null) {
            foregroundService.iconString = previousValue.iconString 
         }
-        if(foregroundService.iconColor == null) {
+        if (foregroundService.iconColor == null) {
            foregroundService.iconColor = previousValue.iconColor 
         }
         val foregroundJson = foregroundService.toJson().toString()

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -293,12 +293,12 @@ data class RadarTrackingOptions(
         /**
          * Determines the notification icon, like `R.drawable.ic_your_icon`. Optional, defaults to `applicationContext.applicationInfo.icon`.
          */
-        val iconString: String? = null,
+        var iconString: String? = null,
 
         /**
          * Determines the color notification icon. Optional.
          */
-        val iconColor: String? = null,
+        var iconColor: String? = null,
     ) {
 
         companion object {

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -344,7 +344,7 @@ class RadarTest {
             "white"))
         assertEquals("bar", RadarSettings.getForegroundService(context).iconString)
         assertEquals("blue", RadarSettings.getForegroundService(context).iconColor)
-        // We do not clear existing values of iconString and iconColor with null values
+        // We do not clear existing values of iconString and iconColor with null values.
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
             text = "Text",
             title = "Title",

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -312,7 +312,7 @@ class RadarTest {
     }
 
     @Test
-    fun test_Radar_setNotificationsOptions(){
+    fun test_Radar_setNotificationsOptions() {
         val notificationOptions = RadarNotificationOptions(
             "foo",
             "red",
@@ -322,12 +322,11 @@ class RadarTest {
             "white")
         Radar.setNotificationOptions(notificationOptions)
         assertEquals(notificationOptions, RadarSettings.getNotificationOptions(context))
-
     }
 
 
     @Test
-    fun test_Radar_notificationSettingDefaults(){
+    fun test_Radar_notificationSettingDefaults() {
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
             text = "Text",
             title = "Title",

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -312,6 +312,58 @@ class RadarTest {
     }
 
     @Test
+    fun test_Radar_setNotificationsOptions(){
+        val notificationsOptions = RadarNotificationsOptions(
+            "foo",
+            "red",
+            "bar",
+            "blue",
+            "hello",
+            "white" )
+        Radar.setNotificationsOptions(notificationsOptions)
+        assertEquals(notificationsOptions,RadarSettings.getNotificationOptions(context))
+
+    }
+
+
+    @Test
+    fun test_Radar_notificationSettingDefaults(){
+        Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
+            text="Text",
+            title = "Title",
+            icon = 1337,
+            updatesOnly = true,
+        ))
+        Radar.setNotificationsOptions(RadarNotificationsOptions(
+            "foo",
+            "red",
+            "bar",
+            "blue",
+            "hello",
+            "white" ))
+        assertEquals("bar",RadarSettings.getForegroundService(context).iconString)
+        assertEquals("blue",RadarSettings.getForegroundService(context).iconColor)
+        Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
+            text="Text",
+            title = "Title",
+            icon = 1337,
+            updatesOnly = true,
+        ))
+        assertEquals("bar",RadarSettings.getForegroundService(context).iconString)
+        assertEquals("blue",RadarSettings.getForegroundService(context).iconColor)
+        Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
+            text="Text",
+            title = "Title",
+            iconString = "test",
+            iconColor = "red",
+            icon = 1337,
+            updatesOnly = true,
+        ))
+        assertEquals("test",RadarSettings.getForegroundService(context).iconString)
+        assertEquals("red",RadarSettings.getForegroundService(context).iconColor)
+    }
+
+    @Test
     fun test_Radar_setMetadata_null() {
         Radar.setMetadata(null)
         assertNull(Radar.getMetadata())

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -334,6 +334,7 @@ class RadarTest {
             icon = 1337,
             updatesOnly = true,
         ))
+        // Radar.setNotificationOptions has side effects on foregroundServiceOptions. 
         Radar.setNotificationsOptions(RadarNotificationsOptions(
             "foo",
             "red",
@@ -343,6 +344,7 @@ class RadarTest {
             "white" ))
         assertEquals("bar",RadarSettings.getForegroundService(context).iconString)
         assertEquals("blue",RadarSettings.getForegroundService(context).iconColor)
+        // We do not clear existing values of iconString and iconColor with null values
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
             text="Text",
             title = "Title",

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -313,15 +313,15 @@ class RadarTest {
 
     @Test
     fun test_Radar_setNotificationsOptions(){
-        val notificationsOptions = RadarNotificationsOptions(
+        val notificationOptions = RadarNotificationOptions(
             "foo",
             "red",
             "bar",
             "blue",
             "hello",
-            "white" )
-        Radar.setNotificationsOptions(notificationsOptions)
-        assertEquals(notificationsOptions,RadarSettings.getNotificationOptions(context))
+            "white")
+        Radar.setNotificationOptions(notificationOptions)
+        assertEquals(notificationOptions, RadarSettings.getNotificationOptions(context))
 
     }
 
@@ -329,40 +329,40 @@ class RadarTest {
     @Test
     fun test_Radar_notificationSettingDefaults(){
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
-            text="Text",
+            text = "Text",
             title = "Title",
             icon = 1337,
             updatesOnly = true,
         ))
         // Radar.setNotificationOptions has side effects on foregroundServiceOptions. 
-        Radar.setNotificationsOptions(RadarNotificationsOptions(
+        Radar.setNotificationOptions(RadarNotificationOptions(
             "foo",
             "red",
             "bar",
             "blue",
             "hello",
-            "white" ))
-        assertEquals("bar",RadarSettings.getForegroundService(context).iconString)
-        assertEquals("blue",RadarSettings.getForegroundService(context).iconColor)
+            "white"))
+        assertEquals("bar", RadarSettings.getForegroundService(context).iconString)
+        assertEquals("blue", RadarSettings.getForegroundService(context).iconColor)
         // We do not clear existing values of iconString and iconColor with null values
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
-            text="Text",
+            text = "Text",
             title = "Title",
             icon = 1337,
             updatesOnly = true,
         ))
-        assertEquals("bar",RadarSettings.getForegroundService(context).iconString)
-        assertEquals("blue",RadarSettings.getForegroundService(context).iconColor)
+        assertEquals("bar", RadarSettings.getForegroundService(context).iconString)
+        assertEquals("blue", RadarSettings.getForegroundService(context).iconColor)
         Radar.setForegroundServiceOptions(RadarTrackingOptions.RadarTrackingOptionsForegroundService(
-            text="Text",
+            text = "Text",
             title = "Title",
             iconString = "test",
             iconColor = "red",
             icon = 1337,
             updatesOnly = true,
         ))
-        assertEquals("test",RadarSettings.getForegroundService(context).iconString)
-        assertEquals("red",RadarSettings.getForegroundService(context).iconColor)
+        assertEquals("test", RadarSettings.getForegroundService(context).iconString)
+        assertEquals("red", RadarSettings.getForegroundService(context).iconColor)
     }
 
     @Test


### PR DESCRIPTION
created a new SDK function `setNotificationOptions` that is used to set notification icon and color for event notifications and foreground service notifications. 
`iconString` and `iconColor` are fields that determine the icon and color of both kind of notificaitons.
They can be overriden by notification specific fields `foregroundServiceIconString`, `foregroundServiceIconColor`, `eventIconString`,`eventIconColor

QA:
Automated tests
Test for setter and getter, and defaulting to existing value tested in code
Manual tests
Setting with `iconString` and `iconColor` fields.
<img width="135" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/93a987e8-c3db-4440-a5bd-8830a6d804d0">

Setting with `foregroundServiceIconString`, `foregroundServiceIconColor`, `eventIconString`,`eventIconColor` and Setting with `foregroundServiceIconString`, `foregroundServiceIconColor`, `iconString` and `iconColor`
<img width="137" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/f4a452bf-3472-4f53-9719-0a5aefee5806">
Verified that not setting this option does not impact current behaviors 
<img width="163" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/b928e090-2b31-444e-8f57-75d481ca87ab">


