### PR TITLE
Fix event confidence field

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.17-beta.1'
+    radarVersion = '3.8.17-beta.2'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.17'
+    radarVersion = '3.8.17-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.17-beta.2'
+    radarVersion = '3.8.17-beta.3'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.16'
+    radarVersion = '3.8.17'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.os.Handler
-import android.util.Log
 import androidx.annotation.RequiresApi
 import io.radar.sdk.model.*
 import io.radar.sdk.model.RadarEvent.RadarEventVerification
@@ -551,10 +550,10 @@ object Radar {
         })
 
         val activityManager = this.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss",Locale.getDefault())
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val crashLists = activityManager.getHistoricalProcessExitReasons(null, 0, 10)
-            if(crashLists.isNotEmpty()) {
+            if (crashLists.isNotEmpty()) {
                 for (crashInfo in crashLists) {
                     if (crashInfo.reason == 10) {
                         this.logger.i("User last force quit at ${dateFormat.format(Date(crashInfo.timestamp))}")

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3,6 +3,7 @@ package io.radar.sdk
 import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.app.Application
+import android.app.ApplicationExitInfo
 import android.content.Context
 import android.location.Location
 import android.os.Build
@@ -555,7 +556,7 @@ object Radar {
             val crashLists = activityManager.getHistoricalProcessExitReasons(null, 0, 10)
             if (crashLists.isNotEmpty()) {
                 for (crashInfo in crashLists) {
-                    if (crashInfo.reason == 10) {
+                    if (crashInfo.reason == ApplicationExitInfo.REASON_USER_REQUESTED) {
                         this.logger.i("User last force quit at ${dateFormat.format(Date(crashInfo.timestamp))}")
                         break
                     }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1,11 +1,13 @@
 package io.radar.sdk
 
 import android.annotation.SuppressLint
+import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.os.Handler
+import android.util.Log
 import androidx.annotation.RequiresApi
 import io.radar.sdk.model.*
 import io.radar.sdk.model.RadarEvent.RadarEventVerification
@@ -14,6 +16,7 @@ import io.radar.sdk.util.RadarReplayBuffer
 import io.radar.sdk.util.RadarSimpleLogBuffer
 import io.radar.sdk.util.RadarSimpleReplayBuffer
 import org.json.JSONObject
+import java.text.SimpleDateFormat
 import java.util.*
 
 /**
@@ -546,6 +549,20 @@ object Radar {
                 }
             }
         })
+
+        val activityManager = this.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss",Locale.getDefault())
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val crashLists = activityManager.getHistoricalProcessExitReasons(null, 0, 10)
+            if(crashLists.isNotEmpty()) {
+                for (crashInfo in crashLists) {
+                    if (crashInfo.reason == 10) {
+                        this.logger.i("User last force quit at ${dateFormat.format(Date(crashInfo.timestamp))}")
+                        break
+                    }
+                }
+            }
+        }
 
         this.initialized = true
 

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3087,11 +3087,17 @@ object Radar {
         RadarSettings.setLogLevel(context, level)
     }
 
+    /**
+     Log application resigning active.
+    */
     @JvmStatic
     fun logResignActive() {
         this.logger.logResignActive()
     }
 
+    /**
+    Log application entering background and flush logs in memory buffer into persistent buffer.
+    */
      @JvmStatic
     fun logEnteringBackground() {
         this.logger.logEnteringBackground()

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3394,10 +3394,10 @@ object Radar {
         logger.e("📍️ Radar error received | status = $status", RadarLogType.SDK_ERROR)
     }
 
-    internal fun sendLog(level: RadarLogLevel, message: String, type: RadarLogType?) {
+    internal fun sendLog(level: RadarLogLevel, message: String, type: RadarLogType?, createdAt: Date = Date()) {
         receiver?.onLog(context, message)
         if (isTestKey()) {
-            logBuffer.write(level, message, type)
+            logBuffer.write(level, message, type, createdAt)
         }
     }
 

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3088,8 +3088,14 @@ object Radar {
     }
 
     @JvmStatic
-    fun logEnteringBackground(){
+    fun logResignActive() {
+        this.logger.logResignActive()
+    }
+
+     @JvmStatic
+    fun logEnteringBackground() {
         this.logger.logEnteringBackground()
+        this.logBuffer.persist()
     }
 
     /**

--- a/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
@@ -2,7 +2,6 @@ package io.radar.sdk
 
 import android.app.ActivityManager
 import java.text.SimpleDateFormat
-
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -61,7 +60,7 @@ internal class RadarLogger(
 
     @RequiresApi(Build.VERSION_CODES.R)
     fun logPastTermination(){
-         val activityManager = this.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val activityManager = this.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
         //Not the cleanest directly calling shared prefs here but using radarsetting also feels hackish. Looking for feedback.
         val sharedPreferences = this.context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
@@ -72,21 +71,18 @@ internal class RadarLogger(
             apply()
         }
         val batteryLevel = this.getBatteryLevel()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ) {
-            val crashLists = activityManager.getHistoricalProcessExitReasons(null, 0, 10)
-            if (crashLists.isNotEmpty()) {
-                for (crashInfo in crashLists) {
-                    
-                    if (crashInfo.timestamp > previousTimestamp) {
-                        this.i("App terminated | with reason: ${crashInfo.getDescription()} | at ${dateFormat.format(Date(crashInfo.timestamp))} | with ${batteryLevel * 100}% battery")
-                        break
-                    }
+        
+        val crashLists = activityManager.getHistoricalProcessExitReasons(null, 0, 10)
+        if (crashLists.isNotEmpty()) {
+            for (crashInfo in crashLists) {                
+                if (crashInfo.timestamp > previousTimestamp) {
+                    this.i("App terminated | with reason: ${crashInfo.getDescription()} | at ${dateFormat.format(Date(crashInfo.timestamp))} | with ${batteryLevel * 100}% battery")
+                    break
                 }
             }
-        }
+        } 
     }
 
-    //TODO:replace with radarBatterManager
     fun getBatteryLevel(): Float {
         val batteryStatus: Intent? = IntentFilter(Intent.ACTION_BATTERY_CHANGED).let { ifilter ->
             this.context.registerReceiver(null, ifilter)
@@ -97,13 +93,13 @@ internal class RadarLogger(
         return batteryPct
     }
 
-    fun logEnteringBackground(){
+    fun logEnteringBackground() {
         val batteryLevel = this.getBatteryLevel()
         val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
         this.i("App entering background | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
     }
 
-     fun logResignActive(){
+     fun logResignActive() {
         val batteryLevel = this.getBatteryLevel()
         val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
         this.i("App resigning active | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")

--- a/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
@@ -103,4 +103,10 @@ internal class RadarLogger(
         this.i("App entering background | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
     }
 
+     fun logResignActive(){
+        val batteryLevel = this.getBatteryLevel()
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        this.i("App resigning active | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
+    }
+
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
@@ -76,7 +76,7 @@ internal class RadarLogger(
         if (crashLists.isNotEmpty()) {
             for (crashInfo in crashLists) {                
                 if (crashInfo.timestamp > previousTimestamp) {
-                    this.i("App terminated | with reason: ${crashInfo.getDescription()} | at ${dateFormat.format(Date(crashInfo.timestamp))} | with ${batteryLevel * 100}% battery")
+                    Radar.sendLog(RadarLogLevel.INFO, "App terminated | with reason: ${crashInfo.getDescription()} | at ${dateFormat.format(Date(crashInfo.timestamp))} | with ${batteryLevel * 100}% battery", null, Date(crashInfo.timestamp))
                     break
                 }
             }

--- a/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
@@ -1,9 +1,19 @@
 package io.radar.sdk
 
+import android.app.ActivityManager
+import java.text.SimpleDateFormat
+
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import io.radar.sdk.Radar.RadarLogLevel
 import io.radar.sdk.Radar.RadarLogType
+import java.util.Date
+import java.util.Locale
 
 internal class RadarLogger(
     private val context: Context
@@ -47,6 +57,50 @@ internal class RadarLogger(
 
             Radar.sendLog(RadarLogLevel.ERROR, message, type)
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun logPastTermination(){
+         val activityManager = this.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        //Not the cleanest directly calling shared prefs here but using radarsetting also feels hackish. Looking for feedback.
+        val sharedPreferences = this.context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
+        val previousTimestamp = sharedPreferences.getLong("last_timestamp", 0)
+        val currentTimestamp = System.currentTimeMillis()
+        with(sharedPreferences.edit()) {
+            putLong("last_timestamp", currentTimestamp)
+            apply()
+        }
+        val batteryLevel = this.getBatteryLevel()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ) {
+            val crashLists = activityManager.getHistoricalProcessExitReasons(null, 0, 10)
+            if (crashLists.isNotEmpty()) {
+                for (crashInfo in crashLists) {
+                    
+                    if (crashInfo.timestamp > previousTimestamp) {
+                        this.i("App terminated | with reason: ${crashInfo.getDescription()} | at ${dateFormat.format(Date(crashInfo.timestamp))} | with ${batteryLevel * 100}% battery")
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    //TODO:replace with radarBatterManager
+    fun getBatteryLevel(): Float {
+        val batteryStatus: Intent? = IntentFilter(Intent.ACTION_BATTERY_CHANGED).let { ifilter ->
+            this.context.registerReceiver(null, ifilter)
+        }
+        val level: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val scale: Int = batteryStatus?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+        val batteryPct: Float = level / scale.toFloat()
+        return batteryPct
+    }
+
+    fun logEnteringBackground(){
+        val batteryLevel = this.getBatteryLevel()
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        this.i("App entering background | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -166,15 +166,15 @@ class RadarEvent(
     /**
      * The confidence levels for events.
      */
-    enum class RadarEventConfidence {
+    enum class RadarEventConfidence(val value: Int)  {
         /** Unknown confidence */
-        NONE,
+        NONE(0),
         /** Low confidence */
-        LOW,
+        LOW(1),
         /** Medium confidence */
-        MEDIUM,
+        MEDIUM(2),
         /** High confidence */
-        HIGH
+        HIGH(3)
     }
 
     /**
@@ -356,7 +356,7 @@ class RadarEvent(
         obj.putOpt(FIELD_TYPE, stringForType(this.type))
         obj.putOpt(FIELD_GEOFENCE, this.geofence?.toJson())
         obj.putOpt(FIELD_PLACE, this.place?.toJson())
-        obj.putOpt(FIELD_CONFIDENCE, this.confidence)
+        obj.putOpt(FIELD_CONFIDENCE, this.confidence.value)
         obj.putOpt(FIELD_DURATION, this.duration)
         obj.putOpt(FIELD_REGION, this.region?.toJson())
         obj.putOpt(FIELD_BEACON, this.beacon?.toJson())

--- a/sdk/src/main/java/io/radar/sdk/model/RadarLog.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarLog.kt
@@ -22,9 +22,11 @@ internal data class RadarLog(
 
         @JvmStatic
         fun fromJson(json: JSONObject): RadarLog {
+            val levelString = json.optString(LEVEL)
+            val typeString = json.optString(TYPE)
             return RadarLog(
-                level = Radar.RadarLogLevel.valueOf(json.optString(LEVEL)),
-                type = Radar.RadarLogType.valueOf(json.optString(TYPE)),
+                level = if (levelString.isNotBlank()) Radar.RadarLogLevel.valueOf(levelString) else Radar.RadarLogLevel.INFO,
+                type = if (typeString.isNotBlank() && typeString!="NONE") Radar.RadarLogType.valueOf(typeString) else null,
                 message = json.optString(MESSAGE),
                 createdAt = Date(json.optLong(CREATED_AT))
             )

--- a/sdk/src/main/java/io/radar/sdk/util/RadarFileSystem.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarFileSystem.kt
@@ -2,6 +2,7 @@ package io.radar.sdk.util
 import android.content.Context
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
 
 class RadarFileSystem(private val context: Context) {
@@ -21,6 +22,8 @@ class RadarFileSystem(private val context: Context) {
             fileInputStream = context.openFileInput(filePath)
             val inputStreamReader = fileInputStream.reader()
             return inputStreamReader.readText()
+        } catch (e: FileNotFoundException) {
+            return ""
         } catch (e: Exception) {
             e.printStackTrace()
         } finally {

--- a/sdk/src/main/java/io/radar/sdk/util/RadarFileSystem.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarFileSystem.kt
@@ -1,0 +1,36 @@
+package io.radar.sdk.util
+import android.content.Context
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+class RadarFileSystem(private val context: Context) {
+    fun writeData(filename: String, content: String) {
+        val fileOutputStream: FileOutputStream
+        try {
+            fileOutputStream = context.openFileOutput(filename, Context.MODE_PRIVATE)
+            fileOutputStream.write(content.toByteArray())
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    fun readFileAtPath(filePath: String): String {
+        var fileInputStream: FileInputStream? = null
+        try {
+            fileInputStream = context.openFileInput(filePath)
+            val inputStreamReader = fileInputStream.reader()
+            return inputStreamReader.readText()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } finally {
+            fileInputStream?.close()
+        }
+        return ""
+    }
+
+    fun deleteFileAtPath(filePath: String): Boolean {
+        val file = File(context.filesDir, filePath)
+        return file.delete()
+    }
+}

--- a/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
@@ -24,6 +24,8 @@ internal interface RadarLogBuffer {
      */
     fun getFlushableLogsStash(): Flushable<RadarLog>
 
-
+    /**
+     * Persist the logs to disk
+     */
     fun persist()
 }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
@@ -23,4 +23,7 @@ internal interface RadarLogBuffer {
      * @return a [Flushable] containing all stored logs
      */
     fun getFlushableLogsStash(): Flushable<RadarLog>
+
+
+    fun persist()
 }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
@@ -2,8 +2,11 @@ package io.radar.sdk.util
 
 import io.radar.sdk.Radar
 import io.radar.sdk.model.RadarLog
+import android.content.Context
 
 internal interface RadarLogBuffer {
+
+    abstract val context: Context
 
     /**
      * Write a log to the buffer

--- a/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
@@ -1,8 +1,9 @@
 package io.radar.sdk.util
 
+import android.content.Context
 import io.radar.sdk.Radar
 import io.radar.sdk.model.RadarLog
-import android.content.Context
+import java.util.Date
 
 internal interface RadarLogBuffer {
 
@@ -14,7 +15,7 @@ internal interface RadarLogBuffer {
      * @param[level] log level
      * @param[message] log message
      */
-    fun write(level: Radar.RadarLogLevel, message: String, type: Radar.RadarLogType?)
+    fun write(level: Radar.RadarLogLevel, message: String, type: Radar.RadarLogType?, createdAt: Date = Date())
 
     /**
      * Creates a stash of the logs currently in the buffer and returns them as a [Flushable] so that a successful

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
@@ -3,15 +3,19 @@ package io.radar.sdk.util
 import io.radar.sdk.Radar
 import io.radar.sdk.model.RadarLog
 import java.util.concurrent.LinkedBlockingDeque
+import android.content.Context
 
 /**
  * Basic Log Buffer implementation that is backed by a field.
  */
-internal class RadarSimpleLogBuffer : RadarLogBuffer {
+internal class
+RadarSimpleLogBuffer(override val context: Context) : RadarLogBuffer{
 
     private companion object {
         const val MAXIMUM_CAPACITY = 1000
         const val HALF_CAPACITY = MAXIMUM_CAPACITY / 2
+        const val radarFileSystem = RadarFileSystem(context)
+        const val logFilePath = "radarLogs.txt"
     }
 
     /**
@@ -20,14 +24,36 @@ internal class RadarSimpleLogBuffer : RadarLogBuffer {
     private val list = LinkedBlockingDeque<RadarLog>(MAXIMUM_CAPACITY)
 
     override fun write(level: Radar.RadarLogLevel, message: String, type: Radar.RadarLogType?) {
+        //push into queue
         if (!list.offer(RadarLog(level, message, type))) {
+            //instead of purge, flush into mem
             purgeOldestLogs()
             list.put(RadarLog(level, message, type))
         }
     }
 
+    // flush into mem
+    // get logs from disk into memory
+    // add logs from memory
+    // if its too long purge
+    // put back into disk
+
+    private fun flush() {
+        val logs = getLogsFromDisk()
+        //CHECK IF THIS IS THE RIGHT ORDERING
+        logs.addAll(list)
+        if (logs.size > MAXIMUM_CAPACITY) {
+            purgeOldestLogs()
+        }
+        writeLogsToDisk(logs)
+    }
+
+
     override fun getFlushableLogsStash(): Flushable<RadarLog> {
-        val logs = mutableListOf<RadarLog>()
+        //get logs from disk into memory
+
+
+        val logs = mutableListOf<RadarLog>(getLogsFromDisk())
         list.drainTo(logs)
         return object : Flushable<RadarLog> {
 
@@ -36,6 +62,12 @@ internal class RadarSimpleLogBuffer : RadarLogBuffer {
             }
 
             override fun onFlush(success: Boolean) {
+                // if success, clear the logs from disk
+                if (success) {
+                    radarFileSystem.delete(logFilePath)
+                }
+                // if not success, push the logs back into list and purge
+                // put back into disk
                 if (!success) {
                     // Reverse order to ensure the logs will purge correctly (oldest logs purged first)
                     logs.reverse()
@@ -44,6 +76,7 @@ internal class RadarSimpleLogBuffer : RadarLogBuffer {
                             purgeOldestLogs()
                         }
                     }
+                    writeLogsToDisk(logs)
                 }
             }
 
@@ -57,5 +90,34 @@ internal class RadarSimpleLogBuffer : RadarLogBuffer {
         val logs = mutableListOf<RadarLog>()
         list.drainTo(logs, HALF_CAPACITY)
         write(Radar.RadarLogLevel.DEBUG, "----- purged oldest logs -----", null)
+    }
+
+    /**
+     * Gets logs from disk
+     */
+    private fun getLogsFromDisk(): LinkedBlockingDeque<RadarLog> {
+        val json = radarFileSystem.read(logFilePath)
+        val logs = LinkedBlockingDeque<RadarLog>()
+        if (json == ""){
+            return logs
+        }
+        val jsonArray = JSONArray(json)
+        for (i in 0 until jsonArray.length()) {
+            val jsonObject = jsonArray.getJSONObject(i)
+            val log = RadarLog.fromJson(jsonObject)
+            logs.add(log)
+        }
+        return logs
+    }
+
+    /**
+    * Writes logs to disk
+    */
+    private fun writeLogsToDisk(logs: LinkedBlockingDeque<RadarLog>) {
+        val jsonArray = JSONArray()
+        for (log in logs) {
+            jsonArray.put(log.toJson())
+        }
+        radarFileSystem.write(logFilePath, jsonArray.toString())
     }
 }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
@@ -5,6 +5,7 @@ import io.radar.sdk.model.RadarLog
 import java.util.concurrent.LinkedBlockingDeque
 import android.content.Context
 import org.json.JSONArray
+import java.util.Date
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -31,10 +32,10 @@ RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer{
 
     private val list = LinkedBlockingDeque<RadarLog>(MAXIMUM_MEMORY_CAPACITY)
 
-    override fun write(level: Radar.RadarLogLevel, message: String, type: Radar.RadarLogType?) {
-        if (!list.offer(RadarLog(level, message, type))) {
+    override fun write(level: Radar.RadarLogLevel, message: String, type: Radar.RadarLogType?, createdAt: Date) {
+        if (!list.offer(RadarLog(level, message, type, createdAt))) {
             persist()
-            list.put(RadarLog(level, message, type))
+            list.put(RadarLog(level, message, type, createdAt))
         }
     }
 

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
@@ -32,7 +32,7 @@ RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer{
     private val list = LinkedBlockingDeque<RadarLog>(MAXIMUM_MEMORY_CAPACITY)
 
     override fun write(level: Radar.RadarLogLevel, message: String, type: Radar.RadarLogType?) {
-        if (!list.offer(RadarLog(level, message, type)) || list.size > MAXIMUM_MEMORY_CAPACITY) {
+        if (!list.offer(RadarLog(level, message, type))) {
             persist()
             list.put(RadarLog(level, message, type))
         }
@@ -78,7 +78,6 @@ RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer{
                             purgeOldestLogs(purgedLogs)
                         }
                     }
-
                     writeLogsToDisk(purgedLogs)
                 }
             }

--- a/sdk/src/test/java/io/radar/sdk/util/RadarFileSystemTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/RadarFileSystemTest.kt
@@ -15,20 +15,16 @@ class RadarFileSystemTest {
     companion object {
         private val context: Context = ApplicationProvider.getApplicationContext()
         private val radarFileSystem: RadarFileSystem = RadarFileSystem(context)
-        private val testPath:String="Test.txt"
+        private val testPath:String = "Test.txt"
     }
 
     @Test
     fun testWriteToFile() {
-
-        radarFileSystem.writeData(testPath,"testing text1")
-        radarFileSystem.writeData(testPath,"testing text2")
-        assertEquals(radarFileSystem.readFileAtPath(testPath),"testing text2")
+        radarFileSystem.writeData(testPath, "testing text1")
+        radarFileSystem.writeData(testPath, "testing text2")
+        assertEquals(radarFileSystem.readFileAtPath(testPath), "testing text2")
         radarFileSystem.deleteFileAtPath(testPath)
-        assertEquals(radarFileSystem.readFileAtPath(testPath),"")
+        assertEquals(radarFileSystem.readFileAtPath(testPath), "")
     }
-
-
-
 
 }

--- a/sdk/src/test/java/io/radar/sdk/util/RadarFileSystemTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/RadarFileSystemTest.kt
@@ -1,0 +1,34 @@
+package io.radar.sdk.util
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk=[Build.VERSION_CODES.P])
+class RadarFileSystemTest {
+    companion object {
+        private val context: Context = ApplicationProvider.getApplicationContext()
+        private val radarFileSystem: RadarFileSystem = RadarFileSystem(context)
+        private val testPath:String="Test.txt"
+    }
+
+    @Test
+    fun testWriteToFile() {
+
+        radarFileSystem.writeData(testPath,"testing text1")
+        radarFileSystem.writeData(testPath,"testing text2")
+        assertEquals(radarFileSystem.readFileAtPath(testPath),"testing text2")
+        radarFileSystem.deleteFileAtPath(testPath)
+        assertEquals(radarFileSystem.readFileAtPath(testPath),"")
+    }
+
+
+
+
+}

--- a/sdk/src/test/java/io/radar/sdk/util/RadarSimpleLogBufferTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/RadarSimpleLogBufferTest.kt
@@ -1,6 +1,8 @@
 package io.radar.sdk.util
 
+import android.content.Context
 import android.os.Build
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.radar.sdk.Radar
 import io.radar.sdk.matchers.RangeMatcher.Companion.isBetween
@@ -20,7 +22,8 @@ class RadarSimpleLogBufferTest {
     fun testLifecycle() {
 
         // Create the log buffer
-        val logBuffer = RadarSimpleLogBuffer()
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val logBuffer = RadarSimpleLogBuffer(context)
 
         // Preconditions
         var flushable = logBuffer.getFlushableLogsStash()
@@ -29,19 +32,19 @@ class RadarSimpleLogBufferTest {
         // Log max number of logs before purging
         val beforeLog = Date()
         val logs = mutableListOf<Pair<Radar.RadarLogLevel, String>>()
-        repeat(500) {
+        repeat(250) {
             val level = Radar.RadarLogLevel.fromInt(it % 5)
             val message = "$it"
             logBuffer.write(level, message, null)
             logs += level to message
         }
-        assertEquals(500, logs.size)
+        assertEquals(250, logs.size)
         val afterLog = Date()
 
         // Verify the log contents
         flushable = logBuffer.getFlushableLogsStash()
         var contents = flushable.get()
-        assertEquals(500, contents.size)
+        assertEquals(250, contents.size)
         contents.forEachIndexed { index, radarLog ->
             assertEquals(logs[index].second, radarLog.message)
             assertEquals(logs[index].first, radarLog.level)
@@ -52,26 +55,27 @@ class RadarSimpleLogBufferTest {
         // Verify the order was preserved
         flushable = logBuffer.getFlushableLogsStash()
         contents = flushable.get()
-        assertEquals(500, logs.size)
-        assertEquals(500, contents.size)
+        assertEquals(250, logs.size)
+        assertEquals(250, contents.size)
         contents.forEachIndexed { index, radarLog ->
             assertEquals(logs[index].second, radarLog.message)
             assertEquals(logs[index].first, radarLog.level)
         }
-
-        // Log 600 more, then put flushed logs back. This will trigger a purge. The most-recent files from the flushable
+        flushable.onFlush(false)
+        // Log 250 more, then put flushed logs back. This will trigger a purge. The most-recent files from the flushable
         // contents should return to the log buffer.
-        repeat(500) {
+        repeat(250) {
             val level = Radar.RadarLogLevel.fromInt(it % 5)
-            val message = "$it"
+            val newVal = it+250
+            val message = "$newVal"
             logBuffer.write(level, message, null)
             logs += level to message
         }
-        flushable.onFlush(false)
+
         flushable = logBuffer.getFlushableLogsStash()
         contents = flushable.get()
-        assertEquals(1000, logs.size)
-        assertEquals(1000, contents.size)
+        assertEquals(500, logs.size)
+        assertEquals(500, contents.size)
         flushable.onFlush(false)
         // One more log will cause a purge
         val level = Radar.RadarLogLevel.DEBUG
@@ -79,14 +83,14 @@ class RadarSimpleLogBufferTest {
         logBuffer.write(level, message, null)
         flushable = logBuffer.getFlushableLogsStash()
         contents = flushable.get()
-        // There should be 502 logs remaining - the extras are from the purge message and the log that was being written.
-        assertEquals(502, contents.size)
-        contents.take(500).forEachIndexed { index, radarLog ->
-            assertEquals(logs[index + 500].second, radarLog.message)
-            assertEquals(logs[index + 500].first, radarLog.level)
+        // There should be 252 logs remaining - the extras are from the purge message and the log that was being written.
+        assertEquals(252, contents.size)
+        contents.take(250).forEachIndexed { index, radarLog ->
+            assertEquals(logs[index + 250].second, radarLog.message)
+            assertEquals(logs[index + 250].first, radarLog.level)
         }
-        assertEquals("----- purged oldest logs -----", contents[500].message)
-        assertEquals(message, contents[501].message)
+        assertEquals("----- purged oldest logs -----", contents[250].message)
+        assertEquals(message, contents[251].message)
 
         // Test behavior of successful log flush
         message = UUID.randomUUID().toString()


### PR DESCRIPTION
The confidence field of the event object was not being converted to a json object correctly, this causes issues with the RN sdk not being able to show this field.

The enumeration to int conversion is fixed in this PR.