### PR TITLE
Fix conversion of confidence enum to int

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.16'
+    radarVersion = '3.8.17'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -166,15 +166,15 @@ class RadarEvent(
     /**
      * The confidence levels for events.
      */
-    enum class RadarEventConfidence {
+    enum class RadarEventConfidence(val value: Int)  {
         /** Unknown confidence */
-        NONE,
+        NONE(0),
         /** Low confidence */
-        LOW,
+        LOW(1),
         /** Medium confidence */
-        MEDIUM,
+        MEDIUM(2),
         /** High confidence */
-        HIGH
+        HIGH(3)
     }
 
     /**
@@ -356,7 +356,7 @@ class RadarEvent(
         obj.putOpt(FIELD_TYPE, stringForType(this.type))
         obj.putOpt(FIELD_GEOFENCE, this.geofence?.toJson())
         obj.putOpt(FIELD_PLACE, this.place?.toJson())
-        obj.putOpt(FIELD_CONFIDENCE, this.confidence)
+        obj.putOpt(FIELD_CONFIDENCE, this.confidence.value)
         obj.putOpt(FIELD_DURATION, this.duration)
         obj.putOpt(FIELD_REGION, this.region?.toJson())
         obj.putOpt(FIELD_BEACON, this.beacon?.toJson())

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -356,7 +356,7 @@ class RadarEvent(
         obj.putOpt(FIELD_TYPE, stringForType(this.type))
         obj.putOpt(FIELD_GEOFENCE, this.geofence?.toJson())
         obj.putOpt(FIELD_PLACE, this.place?.toJson())
-        obj.putOpt(FIELD_CONFIDENCE, this.confidence.value)
+        obj.putOpt(FIELD_CONFIDENCE, this.confidence?.value)
         obj.putOpt(FIELD_DURATION, this.duration)
         obj.putOpt(FIELD_REGION, this.region?.toJson())
         obj.putOpt(FIELD_BEACON, this.beacon?.toJson())


### PR DESCRIPTION
The confidence field of the event object was not being converted to a json object correctly, this causes issues with the RN sdk not being able to show this field.

The enumeration to int conversion is fixed in this PR.

QA:
This Android sdk is installed in waypoint and a single `trackOnce` is called with its results printed. Note how the events in the events array have the confidence field now. 
<img width="1246" alt="image" src="https://github.com/radarlabs/radar-sdk-android/assets/139801512/c27509f5-31cf-47d3-9f22-0f4c053b953b">
