### PR TITLE
Prevent crash with fraud when googlePlayProject is not set.

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.16'
+    radarVersion = '3.8.18'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -960,7 +960,7 @@ object Radar {
         val googlePlayProjectNumber = RadarSettings.getGooglePlayProjectNumber(this.context);
 
         if (googlePlayProjectNumber == 0.toLong()) {
-            callback?.onComplete(RadarStatus.ERROR_PUBLISHABLE_KEY)
+            callback?.onComplete(RadarStatus.ERROR_SERVER)
             return
         }
 

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -960,7 +960,8 @@ object Radar {
         val googlePlayProjectNumber = RadarSettings.getGooglePlayProjectNumber(this.context);
 
         if (googlePlayProjectNumber == 0.toLong()) {
-            callback?.onComplete(RadarStatus.ERROR_SERVER)
+            this.logger.e("Missing Google Play Services project number", RadarLogType.SDK_ERROR)
+            callback?.onComplete(RadarStatus.ERROR_BAD_REQUEST)
             return
         }
 

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -959,6 +959,11 @@ object Radar {
 
         val googlePlayProjectNumber = RadarSettings.getGooglePlayProjectNumber(this.context);
 
+        if (googlePlayProjectNumber == 0.toLong()) {
+            callback?.onComplete(RadarStatus.ERROR_PUBLISHABLE_KEY)
+            return
+        }
+
         locationManager.getLocation(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, RadarLocationSource.FOREGROUND_LOCATION, object : RadarLocationCallback {
             override fun onComplete(status: RadarStatus, location: Location?, stopped: Boolean) {
                 if (status != RadarStatus.SUCCESS || location == null) {


### PR DESCRIPTION
Currently, the `TrackVerified` call assumes that a valid `googlePlayProjectNumber` is stored in `RadarSettings`. However, if this assumption is false for whatever reason, the function will proceed with the default  `googlePlayProjectNumber` value of 0, which will cause a crash with the google play service. 

This PR adds a check to abort the track verified call if `RadarSettings.getGooglePlayProjectNumber(this.context)` returns 0, indicating that the `googlePlayProjectNumber` value has not been set. 

QA: 
Previously, an attempt to call `trackVerified` on staging on android caused a crash, but with this check the `trackVerified` fails gracefully. 
