### PR TITLE
Exponential backoff api wrapper

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarAPIRetryWrapper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarAPIRetryWrapper.kt
@@ -15,18 +15,18 @@ internal class RadarAPIRetryWrapper(private var radarAPIHelper: RadarApiHelper) 
 
 
     internal fun requestWithRetry(context: Context,
-                                       method: String,
-                                       path: String,
-                                       headers: Map<String, String>?,
-                                       params: JSONObject?,
-                                       sleep: Boolean,
-                                       callback: RadarApiHelper.RadarApiCallback? = null,
-                                       extendedTimeout: Boolean = false,
-                                       stream: Boolean = false,
-                                       logPayload: Boolean = true,
-                                       verified: Boolean = false,
-                                       retriedLeft: Int = maxRetries) {
-        val retriesLeftSanitized = minOf(retriedLeft, maxRetries)
+                                  method: String,
+                                  path: String,
+                                  headers: Map<String, String>?,
+                                  params: JSONObject?,
+                                  sleep: Boolean,
+                                  callback: RadarApiHelper.RadarApiCallback? = null,
+                                  extendedTimeout: Boolean = false,
+                                  stream: Boolean = false,
+                                  logPayload: Boolean = true,
+                                  verified: Boolean = false,
+                                  retriesLeft: Int = maxRetries) {
+        val retriesLeftSanitized = minOf(retriesLeft, maxRetries)
         if (retriesLeftSanitized == 0) {
             handler.post {
                 callback?.onComplete(Radar.RadarStatus.ERROR_UNKNOWN)
@@ -41,7 +41,7 @@ internal class RadarAPIRetryWrapper(private var radarAPIHelper: RadarApiHelper) 
                     }
                 } else {
                     // Calculate retry duration with jitter.
-                    val retryDuration = (timeout * timeoutBase.pow((maxRetries - retriedLeft + 1).toDouble()) + Random.nextInt(1000)).toLong()
+                    val retryDuration = (timeout * timeoutBase.pow((maxRetries - retriesLeft + 1).toDouble()) + Random.nextInt(1000)).toLong()
                     Thread.sleep(retryDuration)
                     requestWithRetry(context, method, path, headers, params, sleep, callback, extendedTimeout, stream, logPayload, verified, retriesLeftSanitized - 1)
                 }

--- a/sdk/src/main/java/io/radar/sdk/RadarAPIRetryWrapper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarAPIRetryWrapper.kt
@@ -4,14 +4,17 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import org.json.JSONObject
+import kotlin.math.pow
 import kotlin.random.Random
 
-internal class RadarAPIRetryWrapper(private var radarAPIHelper: RadarApiHelper? = null) {
+internal class RadarAPIRetryWrapper(private var radarAPIHelper: RadarApiHelper) {
     private val handler = Handler(Looper.getMainLooper())
     private val maxRetries = 5
+    private val timeout = 200
+    private val timeoutBase = 2.0
 
 
-    internal open fun requestWithRetry(context: Context,
+    internal fun requestWithRetry(context: Context,
                                        method: String,
                                        path: String,
                                        headers: Map<String, String>?,
@@ -23,8 +26,8 @@ internal class RadarAPIRetryWrapper(private var radarAPIHelper: RadarApiHelper? 
                                        logPayload: Boolean = true,
                                        verified: Boolean = false,
                                        retriedLeft: Int = maxRetries) {
-        val retriedLeftSanitized = minOf(retriedLeft, maxRetries)
-        if (retriedLeftSanitized == 0) {
+        val retriesLeftSanitized = minOf(retriedLeft, maxRetries)
+        if (retriesLeftSanitized == 0) {
             handler.post {
                 callback?.onComplete(Radar.RadarStatus.ERROR_UNKNOWN)
             }
@@ -32,18 +35,19 @@ internal class RadarAPIRetryWrapper(private var radarAPIHelper: RadarApiHelper? 
         }
         val newCallback = object : RadarApiHelper.RadarApiCallback {
             override fun onComplete(status: Radar.RadarStatus, res: JSONObject?) {
-                if ((status !== Radar.RadarStatus.SUCCESS && retriedLeftSanitized === 1) || (status === Radar.RadarStatus.SUCCESS)) {
+                if ((status !== Radar.RadarStatus.SUCCESS && retriesLeftSanitized === 1) || (status === Radar.RadarStatus.SUCCESS)) {
                     handler.post {
                         callback?.onComplete(status, res)
                     }
                 } else {
-                    val retryDuration = (200 * Math.pow(2.0, (maxRetries - retriedLeft + 1).toDouble()) + Random.nextInt(1000)).toLong()
+                    // Calculate retry duration with jitter.
+                    val retryDuration = (timeout * timeoutBase.pow((maxRetries - retriedLeft + 1).toDouble()) + Random.nextInt(1000)).toLong()
                     Thread.sleep(retryDuration)
-                    requestWithRetry(context, method, path, headers, params, sleep, callback, extendedTimeout, stream, logPayload, verified, retriedLeftSanitized - 1)
+                    requestWithRetry(context, method, path, headers, params, sleep, callback, extendedTimeout, stream, logPayload, verified, retriesLeftSanitized - 1)
                 }
             }
         }
-        radarAPIHelper?.request(context, method, path, headers, params, sleep, newCallback, extendedTimeout, stream, logPayload, verified)
+        radarAPIHelper.request(context, method, path, headers, params, sleep, newCallback, extendedTimeout, stream, logPayload, verified)
 
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarAPIRetryWrapper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarAPIRetryWrapper.kt
@@ -1,0 +1,51 @@
+package io.radar.sdk
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import org.json.JSONObject
+import kotlin.random.Random
+
+internal class RadarAPIRetryWrapper(private var radarAPIHelper: RadarApiHelper? = null) {
+    private val handler = Handler(Looper.getMainLooper())
+    private val maxRetries = 5
+
+
+    internal open fun requestWithRetry(context: Context,
+                                       method: String,
+                                       path: String,
+                                       headers: Map<String, String>?,
+                                       params: JSONObject?,
+                                       sleep: Boolean,
+                                       callback: RadarApiHelper.RadarApiCallback? = null,
+                                       extendedTimeout: Boolean = false,
+                                       stream: Boolean = false,
+                                       logPayload: Boolean = true,
+                                       verified: Boolean = false,
+                                       retriedLeft: Int = maxRetries) {
+        val retriedLeftSanitized = minOf(retriedLeft, maxRetries)
+        if (retriedLeftSanitized == 0) {
+            handler.post {
+                callback?.onComplete(Radar.RadarStatus.ERROR_UNKNOWN)
+            }
+            return
+        }
+        val newCallback = object : RadarApiHelper.RadarApiCallback {
+            override fun onComplete(status: Radar.RadarStatus, res: JSONObject?) {
+                if ((status !== Radar.RadarStatus.SUCCESS && retriedLeftSanitized === 1) || (status === Radar.RadarStatus.SUCCESS)) {
+                    handler.post {
+                        callback?.onComplete(status, res)
+                    }
+                } else {
+                    val retryDuration = (200 * Math.pow(2.0, (maxRetries - retriedLeft + 1).toDouble()) + Random.nextInt(1000)).toLong()
+                    Thread.sleep(retryDuration)
+                    requestWithRetry(context, method, path, headers, params, sleep, callback, extendedTimeout, stream, logPayload, verified, retriedLeftSanitized - 1)
+                }
+            }
+        }
+        radarAPIHelper?.request(context, method, path, headers, params, sleep, newCallback, extendedTimeout, stream, logPayload, verified)
+
+    }
+
+
+}

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -19,7 +19,7 @@ internal class RadarApiClient(
     private val context: Context,
     private var logger: RadarLogger,
     internal var apiHelper: RadarApiHelper = RadarApiHelper(logger),
-    internal var apiRetryWrapper: RadarAPIRetryWrapper = RadarAPIRetryWrapper(apiHelper)
+    private var apiRetryWrapper: RadarAPIRetryWrapper = RadarAPIRetryWrapper(apiHelper)
 ) {
 
     interface RadarTrackApiCallback {

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -18,7 +18,8 @@ import java.util.*
 internal class RadarApiClient(
     private val context: Context,
     private var logger: RadarLogger,
-    internal var apiHelper: RadarApiHelper = RadarApiHelper(logger)
+    internal var apiHelper: RadarApiHelper = RadarApiHelper(logger),
+    internal var apiRetryWrapper: RadarAPIRetryWrapper = RadarAPIRetryWrapper(apiHelper)
 ) {
 
     interface RadarTrackApiCallback {
@@ -126,7 +127,7 @@ internal class RadarApiClient(
         val path = "v1/config?${queryParams}"
         val headers = headers(publishableKey)
 
-        apiHelper.request(context, "GET", path, headers, null, false, object : RadarApiHelper.RadarApiCallback {
+        apiRetryWrapper.requestWithRetry(context, "GET", path, headers, null, false, object : RadarApiHelper.RadarApiCallback {
             override fun onComplete(status: RadarStatus, res: JSONObject?) {
                 if (status == RadarStatus.SUCCESS) {
                     Radar.flushLogs()

--- a/sdk/src/test/java/io/radar/sdk/util/RadarAPIRetryTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/RadarAPIRetryTest.kt
@@ -1,0 +1,135 @@
+package io.radar.sdk.util
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.radar.sdk.Radar
+import io.radar.sdk.RadarAPIRetryWrapper
+import io.radar.sdk.RadarApiHelper
+import io.radar.sdk.RadarApiHelperMock
+import io.radar.sdk.RadarTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class RadarAPIRetryTest {
+
+     companion object {
+        private val apiHelperMock = RadarApiHelperMock()
+        private val apiRetryWrapper = RadarAPIRetryWrapper(apiHelperMock)
+        private val context: Context = ApplicationProvider.getApplicationContext()
+
+    }
+
+    @Before
+    fun setUp() {
+        apiHelperMock.retryCounter = 0
+    }
+
+
+    @Test
+    fun testSuccessOnFirstTry() {
+        val latch = CountDownLatch(1)
+        val paramJson = JSONObject()
+        paramJson.put("retry", 1)
+        var callbackStatus: Radar.RadarStatus? = null
+        var successOn: Int? = null
+        val testCallback = object : RadarApiHelper.RadarApiCallback {
+            override fun onComplete(status: Radar.RadarStatus, res: JSONObject?) {
+                callbackStatus = status
+                successOn = res?.getInt("successOn")
+                latch.countDown()
+            }
+        }
+        apiRetryWrapper.requestWithRetry(context, "GET", "http://testPath", null, paramJson, false, testCallback)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        latch.await(RadarTest.LATCH_TIMEOUT, TimeUnit.SECONDS)
+        assertEquals(Radar.RadarStatus.SUCCESS, callbackStatus)
+        assertEquals(successOn,1)
+    }
+    
+    @Test
+    fun testSuccessOnThirdTry() {
+        val latch = CountDownLatch(1)
+        val paramJson = JSONObject()
+        paramJson.put("retry", 3)
+        var callbackStatus: Radar.RadarStatus? = null
+        var successOn: Int? = null
+        val testCallback = object : RadarApiHelper.RadarApiCallback {
+            override fun onComplete(status: Radar.RadarStatus, res: JSONObject?) {
+                callbackStatus = status
+                successOn = res?.getInt("successOn")
+                latch.countDown()
+            }
+        }
+        apiRetryWrapper.requestWithRetry(context, "GET", "http://testPath", null, paramJson, false, testCallback)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        latch.await(RadarTest.LATCH_TIMEOUT, TimeUnit.SECONDS)
+        assertEquals(Radar.RadarStatus.SUCCESS, callbackStatus)
+        assertEquals(successOn,3)
+        
+    }
+
+    @Test
+    fun testSuccessOnLastTry() {
+        val latch = CountDownLatch(1)
+        val paramJson = JSONObject()
+        paramJson.put("retry", 5)
+        var callbackStatus: Radar.RadarStatus? = null
+        var successOn: Int? = null
+        //create a mock callback
+        val testCallback = object : RadarApiHelper.RadarApiCallback {
+            override fun onComplete(status: Radar.RadarStatus, res: JSONObject?) {
+                callbackStatus = status
+                successOn = res?.getInt("successOn")
+                latch.countDown()
+            }
+        }
+        apiRetryWrapper.requestWithRetry(context, "GET", "http://testPath", null, paramJson, false, testCallback)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        latch.await(RadarTest.LATCH_TIMEOUT, TimeUnit.SECONDS)
+        assertEquals(Radar.RadarStatus.SUCCESS, callbackStatus)
+        assertEquals(successOn,5)
+        
+    }
+
+    @Test
+    fun testFailure() {
+        val latch = CountDownLatch(1)
+        val paramJson = JSONObject()
+        paramJson.put("retry", 6)
+        var callbackStatus: Radar.RadarStatus? = null
+        var successOn: Int? = null
+        //create a mock callback
+        val testCallback = object : RadarApiHelper.RadarApiCallback {
+            override fun onComplete(status: Radar.RadarStatus, res: JSONObject?) {
+                callbackStatus = status
+                successOn = res?.getInt("successOn")
+                latch.countDown()
+            }
+        }
+        apiRetryWrapper.requestWithRetry(context, "GET", "http://testPath", null, paramJson, false, testCallback)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        latch.await(RadarTest.LATCH_TIMEOUT, TimeUnit.SECONDS)
+        assertEquals(Radar.RadarStatus.ERROR_UNKNOWN, callbackStatus)
+        assertNull(successOn)
+        
+    }
+
+
+}


### PR DESCRIPTION
Our API helper currently only attempts to make calls once. A more robust solution will be to have exponential backoff. 

The new `RadarAPIRetryWrapper` will allows us to retry network calls up to 5 times, each time with exponentially longer waiting period. 

This PR only changes the `getConfig` call to use exponential backoff but other calls may be changed to use exponential backoff in the future.

QA: Unit tests are implemented within `RadarAPIRetryTest`.  