### PR TITLE
expandUnits -> mailable

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,7 @@
 
 ## 3.8.x to 3.9.0
 - The `Radar.autocomplete(query, near, layers, limit, country, expandUnits, callback)` method is now `Radar.autocomplete(query, near, layers, limit, country, expandUnits, mailable, callback)`.
+  - `expandUnits` has been deprecated and will always be true regardless of value passed in.
 
 ## 3.6.x to 3.7.0
 - Custom events have been renamed to conversions.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,8 @@
 # Migration guides
 
+## 3.8.x to 3.9.0
+- The `Radar.autocomplete(query, near, layers, limit, country, expandUnits, callback)` method is now `Radar.autocomplete(query, near, layers, limit, country, expandUnits, mailable, callback)`.
+
 ## 3.6.x to 3.7.0
 - Custom events have been renamed to conversions.
   - `Radar.sendEvent(customType, metadata, callback)` is now `Radar.logConversion(name, metadata, callback)`.

--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -119,6 +119,28 @@ class MainActivity : AppCompatActivity() {
             origin,
             arrayOf("locality"),
             10,
+            "US",
+            true,
+        ) { status, addresses ->
+            Log.v("example", "Autocomplete: status = $status; address = ${addresses?.get(0)?.formattedAddress}")
+        }
+
+        Radar.autocomplete(
+            "brooklyn",
+            origin,
+            arrayOf("locality"),
+            10,
+            "US",
+            mailable = true
+        ) { status, addresses ->
+            Log.v("example", "Autocomplete: status = $status; address = ${addresses?.get(0)?.formattedAddress}")
+        }
+
+        Radar.autocomplete(
+            "brooklyn",
+            origin,
+            arrayOf("locality"),
+            10,
             "US"
         ) { status, addresses ->
             Log.v("example", "Autocomplete: status = $status; address = ${addresses?.get(0)?.formattedAddress}")

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.19'
+    radarVersion = '3.9.0'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.8.18'
+    radarVersion = '3.8.19'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2287,7 +2287,7 @@ object Radar {
         layers: Array<String>? = null,
         limit: Int? = null,
         country: String? = null,
-        expandUnits: Boolean? = null,
+        mailable: Boolean? = null,
         callback: RadarGeocodeCallback
     ) {
         if (!initialized) {
@@ -2296,7 +2296,7 @@ object Radar {
             return
         }
 
-        apiClient.autocomplete(query, near, layers, limit, country, expandUnits, object : RadarApiClient.RadarGeocodeApiCallback {
+        apiClient.autocomplete(query, near, layers, limit, country, mailable, object : RadarApiClient.RadarGeocodeApiCallback {
             override fun onComplete(status: RadarStatus, res: JSONObject?, addresses: Array<RadarAddress>?) {
                 handler.post {
                     callback.onComplete(status, addresses)
@@ -2324,7 +2324,7 @@ object Radar {
         layers: Array<String>? = null,
         limit: Int? = null,
         country: String? = null,
-        expandUnits: Boolean? = null,
+        mailable: Boolean? = null,
         block: (status: RadarStatus, addresses: Array<RadarAddress>?) -> Unit
     ) {
         autocomplete(
@@ -2333,7 +2333,7 @@ object Radar {
             layers,
             limit,
             country,
-            expandUnits,
+            mailable,
             object : RadarGeocodeCallback {
                 override fun onComplete(status: RadarStatus, addresses: Array<RadarAddress>?) {
                     block(status, addresses)

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2278,7 +2278,7 @@ object Radar {
      * @param[layers] Optional layer filters.
      * @param[limit] The max number of addresses to return. A number between 1 and 100.
      * @param[country] An optional country filter. A string, the unique 2-letter country code.
-     * @param[expandUnits] (Deprecated) Whether to expand units.
+     * @param[expandUnits] (Deprecated) This is always true, regardless of the value passed here.
      * @param[mailable] Whether to only include mailable addresses.
      * @param[callback] A callback.
      */
@@ -2318,7 +2318,7 @@ object Radar {
      * @param[layers] Optional layer filters.
      * @param[limit] The max number of addresses to return. A number between 1 and 100.
      * @param[country] An optional country filter. A string, the unique 2-letter country code.
-     * @param[expandUnits] (Deprecated) Whether to expand units.
+     * @param[expandUnits] (Deprecated) This is always true, regardless of the value passed here.
      * @param[mailable] Whether to only include mailable addresses
      * @param[block] A block callback.
      */

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -2278,6 +2278,8 @@ object Radar {
      * @param[layers] Optional layer filters.
      * @param[limit] The max number of addresses to return. A number between 1 and 100.
      * @param[country] An optional country filter. A string, the unique 2-letter country code.
+     * @param[expandUnits] (Deprecated) Whether to expand units.
+     * @param[mailable] Whether to only include mailable addresses.
      * @param[callback] A callback.
      */
     @JvmStatic
@@ -2287,6 +2289,7 @@ object Radar {
         layers: Array<String>? = null,
         limit: Int? = null,
         country: String? = null,
+        expandUnits: Boolean? = null,
         mailable: Boolean? = null,
         callback: RadarGeocodeCallback
     ) {
@@ -2315,6 +2318,8 @@ object Radar {
      * @param[layers] Optional layer filters.
      * @param[limit] The max number of addresses to return. A number between 1 and 100.
      * @param[country] An optional country filter. A string, the unique 2-letter country code.
+     * @param[expandUnits] (Deprecated) Whether to expand units.
+     * @param[mailable] Whether to only include mailable addresses
      * @param[block] A block callback.
      */
 
@@ -2324,6 +2329,7 @@ object Radar {
         layers: Array<String>? = null,
         limit: Int? = null,
         country: String? = null,
+        expandUnits: Boolean? = null,
         mailable: Boolean? = null,
         block: (status: RadarStatus, addresses: Array<RadarAddress>?) -> Unit
     ) {
@@ -2333,6 +2339,7 @@ object Radar {
             layers,
             limit,
             country,
+            expandUnits,
             mailable,
             object : RadarGeocodeCallback {
                 override fun onComplete(status: RadarStatus, addresses: Array<RadarAddress>?) {

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -839,7 +839,7 @@ internal class RadarApiClient(
         layers: Array<String>? = null,
         limit: Int? = null,
         country: String? = null,
-        expandUnits: Boolean? = null,
+        mailable: Boolean? = null,
         callback: RadarGeocodeApiCallback
     ) {
         val publishableKey = RadarSettings.getPublishableKey(context)
@@ -861,8 +861,8 @@ internal class RadarApiClient(
         if (country != null) {
             queryParams.append("&country=${country}")
         }
-        if (expandUnits != null) {
-            queryParams.append("&expandUnits=${expandUnits}")
+        if (mailable != null) {
+            queryParams.append("&mailable=${mailable}")
         }
 
         val path = "v1/search/autocomplete?${queryParams}"


### PR DESCRIPTION
This PR deprecates the `expandUnits` param for autocomplete and adds `mailable`