### PR TITLE
Kennyhu/mob 18 encrypt sensitive data in device storage from radar sdk

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -62,7 +62,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha02'
+    implementation 'androidx.security:security-crypto:1.0.0'
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -62,7 +62,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha05'
+    implementation 'androidx.security:security-crypto-ktx:1.0.0'
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.9.0'
+    radarVersion = '3.9.3-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -39,7 +39,7 @@ android {
         jvmTarget = "1.8"
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion 31
         buildConfigField "String", "VERSION_NAME", "\"$radarVersion\""
         multiDexEnabled = true
@@ -62,7 +62,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.security:security-crypto-ktx:1.0.0'
+    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha02'
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -62,6 +62,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation 'androidx.security:security-crypto-ktx:1.0.0'
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -62,7 +62,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.security:security-crypto-ktx:1.0.0'
+    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha05'
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.os.Handler
-import androidx.annotation.RequiresApi
 import io.radar.sdk.model.*
 import io.radar.sdk.model.RadarEvent.RadarEventVerification
 import io.radar.sdk.util.RadarLogBuffer
@@ -948,7 +947,6 @@ object Radar {
      *
      * @param[callback] An optional callback.
      */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
     fun trackVerified(callback: RadarTrackCallback? = null) {
         if (!initialized) {
@@ -1014,7 +1012,6 @@ object Radar {
      *
      * @param[block] A block callback.
      */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
     fun trackVerified(block: (status: RadarStatus, location: Location?, events: Array<RadarEvent>?, user: RadarUser?) -> Unit) {
         trackVerified(object : RadarTrackCallback {
@@ -1033,7 +1030,6 @@ object Radar {
      *
      * @param[callback] An optional callback.
      */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
     fun trackVerifiedToken(callback: RadarTrackTokenCallback? = null) {
         if (!initialized) {
@@ -1093,7 +1089,6 @@ object Radar {
      *
      * @param[block] A block callback.
      */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
     fun trackVerifiedToken(block: (status: RadarStatus, token: String?) -> Unit) {
         trackVerifiedToken(object : RadarTrackTokenCallback {
@@ -3335,9 +3330,7 @@ object Radar {
             obj.put("speedAccuracy", location.speedAccuracyMetersPerSecond)
             obj.put("courseAccuracy", location.bearingAccuracyDegrees)
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            obj.put("mocked", location.isFromMockProvider)
-        }
+        obj.put("mocked", location.isFromMockProvider)
         return obj
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -8,24 +8,11 @@ import io.radar.sdk.Radar.RadarAddressVerificationStatus
 import io.radar.sdk.Radar.RadarLocationSource
 import io.radar.sdk.Radar.RadarStatus
 import io.radar.sdk.Radar.locationManager
-import io.radar.sdk.model.RadarAddress
-import io.radar.sdk.model.RadarBeacon
-import io.radar.sdk.model.RadarConfig
-import io.radar.sdk.model.RadarContext
-import io.radar.sdk.model.RadarEvent
-import io.radar.sdk.model.RadarEvent.RadarEventVerification
-import io.radar.sdk.model.RadarGeofence
-import io.radar.sdk.model.RadarLog
-import io.radar.sdk.model.RadarPlace
-import io.radar.sdk.model.RadarReplay
-import io.radar.sdk.model.RadarRouteMatrix
-import io.radar.sdk.model.RadarRoutes
-import io.radar.sdk.model.RadarTrip
-import io.radar.sdk.model.RadarUser
+import io.radar.sdk.model.*
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
-import java.util.EnumSet
+import java.util.*
 
 internal class RadarApiClient(
     private val context: Context,

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -4,16 +4,28 @@ import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.os.SystemClock
-import io.radar.sdk.model.RadarEvent.RadarEventVerification
+import io.radar.sdk.Radar.RadarAddressVerificationStatus
 import io.radar.sdk.Radar.RadarLocationSource
 import io.radar.sdk.Radar.RadarStatus
-import io.radar.sdk.Radar.RadarAddressVerificationStatus
 import io.radar.sdk.Radar.locationManager
-import io.radar.sdk.model.*
+import io.radar.sdk.model.RadarAddress
+import io.radar.sdk.model.RadarBeacon
+import io.radar.sdk.model.RadarConfig
+import io.radar.sdk.model.RadarContext
+import io.radar.sdk.model.RadarEvent
+import io.radar.sdk.model.RadarEvent.RadarEventVerification
+import io.radar.sdk.model.RadarGeofence
+import io.radar.sdk.model.RadarLog
+import io.radar.sdk.model.RadarPlace
+import io.radar.sdk.model.RadarReplay
+import io.radar.sdk.model.RadarRouteMatrix
+import io.radar.sdk.model.RadarRoutes
+import io.radar.sdk.model.RadarTrip
+import io.radar.sdk.model.RadarUser
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
-import java.util.*
+import java.util.EnumSet
 
 internal class RadarApiClient(
     private val context: Context,
@@ -281,7 +293,7 @@ internal class RadarApiClient(
                     params.putOpt("courseAccuracy", location.bearingAccuracyDegrees)
                 }
             }
-            if (!foreground && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            if (!foreground) {
                 val updatedAtMsDiff = (SystemClock.elapsedRealtimeNanos() - location.elapsedRealtimeNanos) / 1000000
                 params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
             }
@@ -298,10 +310,8 @@ internal class RadarApiClient(
             params.putOpt("country", RadarUtils.country)
             params.putOpt("timeZoneOffset", RadarUtils.timeZoneOffset)
             params.putOpt("source", Radar.stringForSource(source))
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                val mocked = location.isFromMockProvider
-                params.putOpt("mocked", mocked)
-            }
+            val mocked = location.isFromMockProvider
+            params.putOpt("mocked", mocked)
             if (tripOptions != null) {
                 val tripOptionsObj = JSONObject()
                 tripOptionsObj.putOpt("version", "2")

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -1,12 +1,12 @@
 package io.radar.sdk
-
 import android.content.Context
 import android.location.Location
 import android.os.Build
 import android.os.SystemClock
-import io.radar.sdk.Radar.RadarAddressVerificationStatus
+import io.radar.sdk.model.RadarEvent.RadarEventVerification
 import io.radar.sdk.Radar.RadarLocationSource
 import io.radar.sdk.Radar.RadarStatus
+import io.radar.sdk.Radar.RadarAddressVerificationStatus
 import io.radar.sdk.Radar.locationManager
 import io.radar.sdk.model.*
 import org.json.JSONArray

--- a/sdk/src/main/java/io/radar/sdk/RadarBatteryManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBatteryManager.kt
@@ -66,14 +66,14 @@ internal class RadarBatteryManager(
     }
 
     private fun isDeviceIdleMode(): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && powerManager != null) {
+        if (powerManager != null) {
             return powerManager.isDeviceIdleMode
         }
         return false
     }
 
     private fun isIgnoringBatteryOptimizations(): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && powerManager != null) {
+        if (powerManager != null) {
             return powerManager.isIgnoringBatteryOptimizations(context.packageName)
         }
         return false

--- a/sdk/src/main/java/io/radar/sdk/RadarBatteryManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBatteryManager.kt
@@ -55,10 +55,7 @@ internal class RadarBatteryManager(
     fun getAppStandbyBucket(): Int? = usageStatsManager?.appStandbyBucket
 
     private fun isPowerSaveMode(): Boolean? {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            return powerManager?.isPowerSaveMode
-        }
-        return null
+        return powerManager?.isPowerSaveMode
     }
 
     private fun getLocationPowerSaveMode(): Int {

--- a/sdk/src/main/java/io/radar/sdk/RadarBeaconUtils.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarBeaconUtils.kt
@@ -11,7 +11,6 @@ import org.json.JSONObject
 import java.nio.ByteBuffer
 import java.util.*
 
-@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal object RadarBeaconUtils {
 
     private const val IBEACON_MANUFACTURER_ID = 76

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -82,11 +82,7 @@ class RadarForegroundService : Service() {
                 val activityClass = Class.forName(it)
                 val intent = Intent(this, activityClass)
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    PendingIntent.FLAG_IMMUTABLE
-                } else {
-                    0
-                }
+                val flags = PendingIntent.FLAG_IMMUTABLE
                 val pendingIntent = PendingIntent.getActivity(this, 0, intent, flags)
                 builder = builder.setContentIntent(pendingIntent)
             }

--- a/sdk/src/main/java/io/radar/sdk/RadarJobScheduler.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarJobScheduler.kt
@@ -17,7 +17,6 @@ import io.radar.sdk.Radar.stringForSource
 import io.radar.sdk.model.RadarBeacon
 import java.util.concurrent.atomic.AtomicInteger
 
-@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 class RadarJobScheduler : JobService() {
 
     internal companion object {

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationReceiver.kt
@@ -113,7 +113,7 @@ class RadarLocationReceiver : BroadcastReceiver() {
                     return
                 }
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !RadarForegroundService.started) {
+                if (!RadarForegroundService.started) {
                     RadarJobScheduler.scheduleJob(context, location, source)
                 } else {
                     Radar.handleLocation(context, location, source)
@@ -127,7 +127,7 @@ class RadarLocationReceiver : BroadcastReceiver() {
                     return
                 }
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !RadarForegroundService.started) {
+                if (!RadarForegroundService.started) {
                     RadarJobScheduler.scheduleJob(context, location, source)
                 } else {
                     Radar.handleLocation(context, location, source)

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -6,6 +6,8 @@ import android.location.Location
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 import io.radar.sdk.model.RadarBeacon
 
 internal object RadarState {
@@ -39,7 +41,19 @@ internal object RadarState {
     private const val KEY_LAST_BEACON_UIDS = "last_beacon_uids"
 
     private fun getSharedPreferences(context: Context): SharedPreferences {
-        return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
+       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+           val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+            return EncryptedSharedPreferences.create(
+                "PreferencesFilename",
+                masterKeyAlias,
+                context,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        } else {
+            return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
+        }
     }
 
     internal fun getLastLocation(context: Context): Location? {

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -44,56 +44,60 @@ internal object RadarState {
         return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
     }
 
+    @RequiresApi(Build.VERSION_CODES.M)
     private fun getEncryptedSharedPreferences(context: Context): SharedPreferences {
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-//            val masterKeyAlias = MasterKey.Builder(context)
-//            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-//                .build()
-//
-//            return EncryptedSharedPreferences.create(
-//                context,
-//                "PreferencesFilename",
-//                masterKeyAlias,
-//                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-//                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-//            )
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                EncryptedSharedPreferences.create(
-                    "RadarState",
-                    MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
-                    context,
-                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-                )
-            } else {
-                context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
-            }
-//        } else {
-//            return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
-//        }
+
+        return EncryptedSharedPreferences.create(
+            "RadarState",
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+
     }
 
     // TODO: migration: pseudo code, attempt to check encoded version, if they do not have it, fall back to
     // non encrypted version, before returning default. "eventual migration" just like in Segment.
 
     private fun getFloat(context: Context, key: String, default: Float): Float {
-        return getEncryptedSharedPreferences(context).getFloat(key, getSharedPreferences(context).getFloat(key, default))
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getEncryptedSharedPreferences(context).getFloat(key, getSharedPreferences(context).getFloat(key, default))
+        } else {
+            getSharedPreferences(context).getFloat(key, default)
+        }
     }
 
     private fun getLong(context: Context, key: String, default: Long): Long {
-        return getEncryptedSharedPreferences(context).getLong(key, getSharedPreferences(context).getLong(key, default))
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getEncryptedSharedPreferences(context).getLong(key, getSharedPreferences(context).getLong(key, default))
+        } else {
+            getSharedPreferences(context).getLong(key, default)
+        }
     }
 
     private fun getString(context: Context, key: String, default: String?): String? {
-        return getEncryptedSharedPreferences(context).getString(key, getSharedPreferences(context).getString(key, default))
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getEncryptedSharedPreferences(context).getString(key, getSharedPreferences(context).getString(key, default))
+        } else {
+            getSharedPreferences(context).getString(key, default)
+        }
     }
 
     private fun getStringSet(context: Context, key: String, default: Set<String>?): Set<String>? {
-        return getEncryptedSharedPreferences(context).getStringSet(key, getSharedPreferences(context).getStringSet(key, default))
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getEncryptedSharedPreferences(context).getStringSet(key, getSharedPreferences(context).getStringSet(key, default))
+        } else {
+            getSharedPreferences(context).getStringSet(key, default)
+        }
     }
 
     private fun getBoolean(context: Context, key: String, default: Boolean): Boolean {
-        return getEncryptedSharedPreferences(context).getBoolean(key, getSharedPreferences(context).getBoolean(key, default))
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getEncryptedSharedPreferences(context).getBoolean(key, getSharedPreferences(context).getBoolean(key, default))
+        } else {
+            getSharedPreferences(context).getBoolean(key, default)
+        }
     }
 
     internal fun getLastLocation(context: Context): Location? {

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -3,8 +3,6 @@ package io.radar.sdk
 import android.content.Context
 import android.content.SharedPreferences
 import android.location.Location
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
@@ -44,7 +42,6 @@ internal object RadarState {
         return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun getEncryptedSharedPreferences(context: Context): SharedPreferences {
 
         return EncryptedSharedPreferences.create(
@@ -61,43 +58,24 @@ internal object RadarState {
     // non encrypted version, before returning default. "eventual migration" just like in Segment.
 
     private fun getFloat(context: Context, key: String, default: Float): Float {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            getEncryptedSharedPreferences(context).getFloat(key, getSharedPreferences(context).getFloat(key, default))
-        } else {
-            getSharedPreferences(context).getFloat(key, default)
-        }
+        return getEncryptedSharedPreferences(context).getFloat(key, getSharedPreferences(context).getFloat(key, default))
     }
 
     private fun getLong(context: Context, key: String, default: Long): Long {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            getEncryptedSharedPreferences(context).getLong(key, getSharedPreferences(context).getLong(key, default))
-        } else {
-            getSharedPreferences(context).getLong(key, default)
-        }
+        return getEncryptedSharedPreferences(context).getLong(key, getSharedPreferences(context).getLong(key, default))
     }
 
     private fun getString(context: Context, key: String, default: String?): String? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            getEncryptedSharedPreferences(context).getString(key, getSharedPreferences(context).getString(key, default))
-        } else {
-            getSharedPreferences(context).getString(key, default)
-        }
+        return getEncryptedSharedPreferences(context).getString(key, getSharedPreferences(context).getString(key, default))
+
     }
 
     private fun getStringSet(context: Context, key: String, default: Set<String>?): Set<String>? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            getEncryptedSharedPreferences(context).getStringSet(key, getSharedPreferences(context).getStringSet(key, default))
-        } else {
-            getSharedPreferences(context).getStringSet(key, default)
-        }
+        return getEncryptedSharedPreferences(context).getStringSet(key, getSharedPreferences(context).getStringSet(key, default))
     }
 
     private fun getBoolean(context: Context, key: String, default: Boolean): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            getEncryptedSharedPreferences(context).getBoolean(key, getSharedPreferences(context).getBoolean(key, default))
-        } else {
-            getSharedPreferences(context).getBoolean(key, default)
-        }
+        return getEncryptedSharedPreferences(context).getBoolean(key, getSharedPreferences(context).getBoolean(key, default))
     }
 
     internal fun getLastLocation(context: Context): Location? {
@@ -279,34 +257,28 @@ internal object RadarState {
         getSharedPreferences(context).edit { putStringSet(KEY_BEACON_IDS, beaconIds) }
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun getLastBeacons(context: Context): Array<RadarBeacon>? {
         val set = getStringSet(context, KEY_LAST_BEACONS, null)
         return RadarBeaconUtils.beaconsForStringSet(set)
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun setLastBeacons(context: Context, beacons: Array<RadarBeacon>?) {
         val set = RadarBeaconUtils.stringSetForBeacons(beacons)
         getSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACONS, set) }
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun getLastBeaconUUIDs(context: Context): Array<String>? {
         return getStringSet(context, KEY_LAST_BEACON_UUIDS, null)?.toTypedArray()
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun setLastBeaconUUIDs(context: Context, uuids: Array<String>?) {
         getSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACON_UUIDS, uuids?.toSet()) }
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun getLastBeaconUIDs(context: Context): Array<String>? {
         return getStringSet(context, KEY_LAST_BEACON_UIDS, null)?.toTypedArray()
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun setLastBeaconUIDs(context: Context, uids: Array<String>?) {
         getSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACON_UIDS, uids?.toSet()) }
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -46,11 +46,20 @@ internal object RadarState {
 
     private fun getEncryptedSharedPreferences(context: Context): SharedPreferences {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
-
+//            val masterKeyAlias = MasterKey.Builder(context)
+//            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+//                .build()
+//
+//            return EncryptedSharedPreferences.create(
+//                context,
+//                "PreferencesFilename",
+//                masterKeyAlias,
+//                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+//                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+//            )
             return EncryptedSharedPreferences.create(
-                "PreferencesFilename",
-                masterKeyAlias,
+                "RadarState",
+                MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
                 context,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
@@ -77,6 +86,10 @@ internal object RadarState {
 
     private fun getStringSet(context: Context, key: String, default: Set<String>?): Set<String>? {
         return getEncryptedSharedPreferences(context).getStringSet(key, getSharedPreferences(context).getStringSet(key, default))
+    }
+
+    private fun getBoolean(context: Context, key: String, default: Boolean): Boolean {
+        return getEncryptedSharedPreferences(context).getBoolean(key, getSharedPreferences(context).getBoolean(key, default))
     }
 
     internal fun getLastLocation(context: Context): Location? {
@@ -162,7 +175,7 @@ internal object RadarState {
     }
 
     internal fun getStopped(context: Context): Boolean {
-        return getBoolean(KEY_STOPPED, false)
+        return getBoolean(context, KEY_STOPPED, false)
     }
 
     internal fun setStopped(context: Context, stopped: Boolean) {
@@ -178,7 +191,7 @@ internal object RadarState {
     }
 
     internal fun getCanExit(context: Context): Boolean {
-        return getBoolean(KEY_CAN_EXIT, true)
+        return getBoolean(context, KEY_CAN_EXIT, true)
     }
 
     internal fun setCanExit(context: Context, canExit: Boolean) {
@@ -227,7 +240,7 @@ internal object RadarState {
     }
 
     internal fun getGeofenceIds(context: Context): MutableSet<String>? {
-        return getStringSet(KEY_GEOFENCE_IDS, null)
+        return getStringSet(context, KEY_GEOFENCE_IDS, null)?.toMutableSet()
     }
 
     internal fun setGeofenceIds(context: Context, geofenceIds: Set<String>?) {
@@ -243,7 +256,7 @@ internal object RadarState {
     }
 
     internal fun getRegionIds(context: Context): MutableSet<String>? {
-        return getStringSet(KEY_REGION_IDS, null)
+        return getStringSet(context, KEY_REGION_IDS, null)?.toMutableSet()
     }
 
     internal fun setRegionIds(context: Context, regionIds: Set<String>?) {
@@ -251,7 +264,7 @@ internal object RadarState {
     }
 
     internal fun getBeaconIds(context: Context): MutableSet<String>? {
-        return getStringSet(context, KEY_BEACON_IDS, null)
+        return getStringSet(context, KEY_BEACON_IDS, null)?.toMutableSet()
     }
 
     internal fun setBeaconIds(context: Context, beaconIds: Set<String>?) {

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -41,8 +41,12 @@ internal object RadarState {
     private const val KEY_LAST_BEACON_UIDS = "last_beacon_uids"
 
     private fun getSharedPreferences(context: Context): SharedPreferences {
-       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-           val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
+    }
+
+    private fun getEncryptedSharedPreferences(context: Context): SharedPreferences {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
 
             return EncryptedSharedPreferences.create(
                 "PreferencesFilename",
@@ -56,12 +60,31 @@ internal object RadarState {
         }
     }
 
+    // TODO: migration: pseudo code, attempt to check encoded version, if they do not have it, fall back to
+    // non encrypted version, before returning default. "eventual migration" just like in Segment.
+
+    private fun getFloat(context: Context, key: String, default: Float): Float {
+        return getEncryptedSharedPreferences(context).getFloat(key, getSharedPreferences(context).getFloat(key, default))
+    }
+
+    private fun getLong(context: Context, key: String, default: Long): Long {
+        return getEncryptedSharedPreferences(context).getLong(key, getSharedPreferences(context).getLong(key, default))
+    }
+
+    private fun getString(context: Context, key: String, default: String?): String? {
+        return getEncryptedSharedPreferences(context).getString(key, getSharedPreferences(context).getString(key, default))
+    }
+
+    private fun getStringSet(context: Context, key: String, default: Set<String>?): Set<String>? {
+        return getEncryptedSharedPreferences(context).getStringSet(key, getSharedPreferences(context).getStringSet(key, default))
+    }
+
     internal fun getLastLocation(context: Context): Location? {
-        val lastLocationLatitude = getSharedPreferences(context).getFloat(KEY_LAST_LOCATION_LATITUDE, 0f)
-        val lastLocationLongitude = getSharedPreferences(context).getFloat(KEY_LAST_LOCATION_LONGITUDE, 0f)
-        val lastLocationAccuracy = getSharedPreferences(context).getFloat(KEY_LAST_LOCATION_ACCURACY, 0f)
-        val lastLocationProvider = getSharedPreferences(context).getString(KEY_LAST_LOCATION_PROVIDER, "RadarSDK")
-        val lastLocationTime = getSharedPreferences(context).getLong(KEY_LAST_LOCATION_TIME, 0L)
+        val lastLocationLatitude = getFloat(context, KEY_LAST_LOCATION_LATITUDE, 0f)
+        val lastLocationLongitude = getFloat(context, KEY_LAST_LOCATION_LONGITUDE, 0f)
+        val lastLocationAccuracy = getFloat(context, KEY_LAST_LOCATION_ACCURACY, 0f)
+        val lastLocationProvider = getString(context, KEY_LAST_LOCATION_PROVIDER, "RadarSDK")
+        val lastLocationTime = getLong(context, KEY_LAST_LOCATION_TIME, 0L)
         val location = Location(lastLocationProvider)
         location.latitude = lastLocationLatitude.toDouble()
         location.longitude = lastLocationLongitude.toDouble()
@@ -98,11 +121,11 @@ internal object RadarState {
     }
 
     internal fun getLastMovedLocation(context: Context): Location? {
-        val lastMovedLocationLatitude = getSharedPreferences(context).getFloat(KEY_LAST_MOVED_LOCATION_LATITUDE, 0f)
-        val lastMovedLocationLongitude = getSharedPreferences(context).getFloat(KEY_LAST_MOVED_LOCATION_LONGITUDE, 0f)
-        val lastMovedLocationAccuracy = getSharedPreferences(context).getFloat(KEY_LAST_MOVED_LOCATION_ACCURACY, 0f)
-        val lastMovedLocationProvider = getSharedPreferences(context).getString(KEY_LAST_MOVED_LOCATION_PROVIDER, "RadarSDK")
-        val lastMovedLocationTime = getSharedPreferences(context).getLong(KEY_LAST_MOVED_LOCATION_TIME, 0L)
+        val lastMovedLocationLatitude = getFloat(context, KEY_LAST_MOVED_LOCATION_LATITUDE, 0f)
+        val lastMovedLocationLongitude = getFloat(context, KEY_LAST_MOVED_LOCATION_LONGITUDE, 0f)
+        val lastMovedLocationAccuracy = getFloat(context, KEY_LAST_MOVED_LOCATION_ACCURACY, 0f)
+        val lastMovedLocationProvider = getString(context, KEY_LAST_MOVED_LOCATION_PROVIDER, "RadarSDK")
+        val lastMovedLocationTime = getLong(context, KEY_LAST_MOVED_LOCATION_TIME, 0L)
         val location = Location(lastMovedLocationProvider)
         location.latitude = lastMovedLocationLatitude.toDouble()
         location.longitude = lastMovedLocationLongitude.toDouble()
@@ -131,7 +154,7 @@ internal object RadarState {
     }
 
     internal fun getLastMovedAt(context: Context): Long {
-        return getSharedPreferences(context).getLong(KEY_LAST_MOVED_AT, 0L)
+        return getLong(context, KEY_LAST_MOVED_AT, 0L)
     }
 
     internal fun setLastMovedAt(context: Context, lastMovedAt: Long) {
@@ -139,7 +162,7 @@ internal object RadarState {
     }
 
     internal fun getStopped(context: Context): Boolean {
-        return getSharedPreferences(context).getBoolean(KEY_STOPPED, false)
+        return getBoolean(KEY_STOPPED, false)
     }
 
     internal fun setStopped(context: Context, stopped: Boolean) {
@@ -151,11 +174,11 @@ internal object RadarState {
     }
 
     internal fun getLastSentAt(context: Context): Long {
-        return getSharedPreferences(context).getLong(KEY_LAST_SENT_AT, 0L)
+        return getLong(context, KEY_LAST_SENT_AT, 0L)
     }
 
     internal fun getCanExit(context: Context): Boolean {
-        return getSharedPreferences(context).getBoolean(KEY_CAN_EXIT, true)
+        return getBoolean(KEY_CAN_EXIT, true)
     }
 
     internal fun setCanExit(context: Context, canExit: Boolean) {
@@ -163,11 +186,11 @@ internal object RadarState {
     }
 
     internal fun getLastFailedStoppedLocation(context: Context): Location? {
-        val lastFailedStoppedLocationLatitude = getSharedPreferences(context).getFloat(KEY_LAST_FAILED_STOPPED_LOCATION_LATITUDE, 0f)
-        val lastFailedStoppedLocationLongitude = getSharedPreferences(context).getFloat(KEY_LAST_FAILED_STOPPED_LOCATION_LONGITUDE, 0f)
-        val lastFailedStoppedLocationAccuracy = getSharedPreferences(context).getFloat(KEY_LAST_FAILED_STOPPED_LOCATION_ACCURACY, 0f)
-        val lastFailedStoppedLocationProvider = getSharedPreferences(context).getString(KEY_LAST_FAILED_STOPPED_LOCATION_PROVIDER, "RadarSDK")
-        val lastFailedStoppedLocationTime = getSharedPreferences(context).getLong(KEY_LAST_FAILED_STOPPED_LOCATION_TIME, 0L)
+        val lastFailedStoppedLocationLatitude = getFloat(context, KEY_LAST_FAILED_STOPPED_LOCATION_LATITUDE, 0f)
+        val lastFailedStoppedLocationLongitude = getFloat(context, KEY_LAST_FAILED_STOPPED_LOCATION_LONGITUDE, 0f)
+        val lastFailedStoppedLocationAccuracy = getFloat(context, KEY_LAST_FAILED_STOPPED_LOCATION_ACCURACY, 0f)
+        val lastFailedStoppedLocationProvider = getString(context, KEY_LAST_FAILED_STOPPED_LOCATION_PROVIDER, "RadarSDK")
+        val lastFailedStoppedLocationTime = getLong(context, KEY_LAST_FAILED_STOPPED_LOCATION_TIME, 0L)
         val location = Location(lastFailedStoppedLocationProvider)
         location.latitude = lastFailedStoppedLocationLatitude.toDouble()
         location.longitude = lastFailedStoppedLocationLongitude.toDouble()
@@ -204,7 +227,7 @@ internal object RadarState {
     }
 
     internal fun getGeofenceIds(context: Context): MutableSet<String>? {
-        return getSharedPreferences(context).getStringSet(KEY_GEOFENCE_IDS, null)
+        return getStringSet(KEY_GEOFENCE_IDS, null)
     }
 
     internal fun setGeofenceIds(context: Context, geofenceIds: Set<String>?) {
@@ -212,7 +235,7 @@ internal object RadarState {
     }
 
     internal fun getPlaceId(context: Context): String? {
-        return getSharedPreferences(context).getString(KEY_PLACE_ID, null)
+        return getString(context, KEY_PLACE_ID, null)
     }
 
     internal fun setPlaceId(context: Context, placeId: String?) {
@@ -220,7 +243,7 @@ internal object RadarState {
     }
 
     internal fun getRegionIds(context: Context): MutableSet<String>? {
-        return getSharedPreferences(context).getStringSet(KEY_REGION_IDS, null)
+        return getStringSet(KEY_REGION_IDS, null)
     }
 
     internal fun setRegionIds(context: Context, regionIds: Set<String>?) {
@@ -228,7 +251,7 @@ internal object RadarState {
     }
 
     internal fun getBeaconIds(context: Context): MutableSet<String>? {
-        return getSharedPreferences(context).getStringSet(KEY_BEACON_IDS, null)
+        return getStringSet(context, KEY_BEACON_IDS, null)
     }
 
     internal fun setBeaconIds(context: Context, beaconIds: Set<String>?) {
@@ -237,7 +260,7 @@ internal object RadarState {
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun getLastBeacons(context: Context): Array<RadarBeacon>? {
-        val set = getSharedPreferences(context).getStringSet(KEY_LAST_BEACONS, null)
+        val set = getStringSet(context, KEY_LAST_BEACONS, null)
         return RadarBeaconUtils.beaconsForStringSet(set)
     }
 
@@ -249,7 +272,7 @@ internal object RadarState {
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun getLastBeaconUUIDs(context: Context): Array<String>? {
-        return getSharedPreferences(context).getStringSet(KEY_LAST_BEACON_UUIDS, null)?.toTypedArray()
+        return getStringSet(context, KEY_LAST_BEACON_UUIDS, null)?.toTypedArray()
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
@@ -259,7 +282,7 @@ internal object RadarState {
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     internal fun getLastBeaconUIDs(context: Context): Array<String>? {
-        return getSharedPreferences(context).getStringSet(KEY_LAST_BEACON_UIDS, null)?.toTypedArray()
+        return getStringSet(context, KEY_LAST_BEACON_UIDS, null)?.toTypedArray()
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -99,7 +99,7 @@ internal object RadarState {
 
     internal fun setLastLocation(context: Context, location: Location?) {
         if (location == null || !RadarUtils.valid(location)) {
-            getSharedPreferences(context).edit {
+            getEncryptedSharedPreferences(context).edit {
                 remove(KEY_LAST_LOCATION_LATITUDE)
                 remove(KEY_LAST_LOCATION_LONGITUDE)
                 remove(KEY_LAST_LOCATION_ACCURACY)
@@ -110,7 +110,7 @@ internal object RadarState {
             return
         }
 
-        getSharedPreferences(context).edit {
+        getEncryptedSharedPreferences(context).edit {
             putFloat(KEY_LAST_LOCATION_LATITUDE, location.latitude.toFloat())
             putFloat(KEY_LAST_LOCATION_LONGITUDE, location.longitude.toFloat())
             putFloat(KEY_LAST_LOCATION_ACCURACY, location.accuracy)
@@ -143,7 +143,7 @@ internal object RadarState {
             return
         }
 
-        getSharedPreferences(context).edit {
+        getEncryptedSharedPreferences(context).edit {
             putFloat(KEY_LAST_MOVED_LOCATION_LATITUDE, location.latitude.toFloat())
             putFloat(KEY_LAST_MOVED_LOCATION_LONGITUDE, location.longitude.toFloat())
             putFloat(KEY_LAST_MOVED_LOCATION_ACCURACY, location.accuracy)
@@ -157,7 +157,7 @@ internal object RadarState {
     }
 
     internal fun setLastMovedAt(context: Context, lastMovedAt: Long) {
-        getSharedPreferences(context).edit { putLong(KEY_LAST_MOVED_AT, lastMovedAt) }
+        getEncryptedSharedPreferences(context).edit { putLong(KEY_LAST_MOVED_AT, lastMovedAt) }
     }
 
     internal fun getStopped(context: Context): Boolean {
@@ -165,11 +165,11 @@ internal object RadarState {
     }
 
     internal fun setStopped(context: Context, stopped: Boolean) {
-        getSharedPreferences(context).edit { putBoolean(KEY_STOPPED, stopped) }
+        getEncryptedSharedPreferences(context).edit { putBoolean(KEY_STOPPED, stopped) }
     }
 
     internal fun updateLastSentAt(context: Context) {
-        getSharedPreferences(context).edit { putLong(KEY_LAST_SENT_AT,  System.currentTimeMillis()) }
+        getEncryptedSharedPreferences(context).edit { putLong(KEY_LAST_SENT_AT,  System.currentTimeMillis()) }
     }
 
     internal fun getLastSentAt(context: Context): Long {
@@ -181,7 +181,7 @@ internal object RadarState {
     }
 
     internal fun setCanExit(context: Context, canExit: Boolean) {
-        getSharedPreferences(context).edit { putBoolean(KEY_CAN_EXIT, canExit) }
+        getEncryptedSharedPreferences(context).edit { putBoolean(KEY_CAN_EXIT, canExit) }
     }
 
     internal fun getLastFailedStoppedLocation(context: Context): Location? {
@@ -205,7 +205,7 @@ internal object RadarState {
 
     internal fun setLastFailedStoppedLocation(context: Context, location: Location?) {
         if (location == null || !RadarUtils.valid(location)) {
-            getSharedPreferences(context).edit {
+            getEncryptedSharedPreferences(context).edit {
                 remove(KEY_LAST_FAILED_STOPPED_LOCATION_LATITUDE)
                 remove(KEY_LAST_FAILED_STOPPED_LOCATION_LONGITUDE)
                 remove(KEY_LAST_FAILED_STOPPED_LOCATION_ACCURACY)
@@ -216,7 +216,7 @@ internal object RadarState {
             return
         }
 
-        getSharedPreferences(context).edit {
+        getEncryptedSharedPreferences(context).edit {
             putFloat(KEY_LAST_FAILED_STOPPED_LOCATION_LATITUDE, location.latitude.toFloat())
             putFloat(KEY_LAST_FAILED_STOPPED_LOCATION_LONGITUDE, location.longitude.toFloat())
             putFloat(KEY_LAST_FAILED_STOPPED_LOCATION_ACCURACY, location.accuracy)
@@ -230,7 +230,7 @@ internal object RadarState {
     }
 
     internal fun setGeofenceIds(context: Context, geofenceIds: Set<String>?) {
-        getSharedPreferences(context).edit { putStringSet(KEY_GEOFENCE_IDS, geofenceIds) }
+        getEncryptedSharedPreferences(context).edit { putStringSet(KEY_GEOFENCE_IDS, geofenceIds) }
     }
 
     internal fun getPlaceId(context: Context): String? {
@@ -238,7 +238,7 @@ internal object RadarState {
     }
 
     internal fun setPlaceId(context: Context, placeId: String?) {
-        getSharedPreferences(context).edit { putString(KEY_PLACE_ID, placeId) }
+        getEncryptedSharedPreferences(context).edit { putString(KEY_PLACE_ID, placeId) }
     }
 
     internal fun getRegionIds(context: Context): MutableSet<String>? {
@@ -246,7 +246,7 @@ internal object RadarState {
     }
 
     internal fun setRegionIds(context: Context, regionIds: Set<String>?) {
-        getSharedPreferences(context).edit { putStringSet(KEY_REGION_IDS, regionIds) }
+        getEncryptedSharedPreferences(context).edit { putStringSet(KEY_REGION_IDS, regionIds) }
     }
 
     internal fun getBeaconIds(context: Context): MutableSet<String>? {
@@ -254,7 +254,7 @@ internal object RadarState {
     }
 
     internal fun setBeaconIds(context: Context, beaconIds: Set<String>?) {
-        getSharedPreferences(context).edit { putStringSet(KEY_BEACON_IDS, beaconIds) }
+        getEncryptedSharedPreferences(context).edit { putStringSet(KEY_BEACON_IDS, beaconIds) }
     }
 
     internal fun getLastBeacons(context: Context): Array<RadarBeacon>? {
@@ -264,7 +264,7 @@ internal object RadarState {
 
     internal fun setLastBeacons(context: Context, beacons: Array<RadarBeacon>?) {
         val set = RadarBeaconUtils.stringSetForBeacons(beacons)
-        getSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACONS, set) }
+        getEncryptedSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACONS, set) }
     }
 
     internal fun getLastBeaconUUIDs(context: Context): Array<String>? {
@@ -272,7 +272,7 @@ internal object RadarState {
     }
 
     internal fun setLastBeaconUUIDs(context: Context, uuids: Array<String>?) {
-        getSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACON_UUIDS, uuids?.toSet()) }
+        getEncryptedSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACON_UUIDS, uuids?.toSet()) }
     }
 
     internal fun getLastBeaconUIDs(context: Context): Array<String>? {
@@ -280,7 +280,7 @@ internal object RadarState {
     }
 
     internal fun setLastBeaconUIDs(context: Context, uids: Array<String>?) {
-        getSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACON_UIDS, uids?.toSet()) }
+        getEncryptedSharedPreferences(context).edit { putStringSet(KEY_LAST_BEACON_UIDS, uids?.toSet()) }
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -45,7 +45,7 @@ internal object RadarState {
     }
 
     private fun getEncryptedSharedPreferences(context: Context): SharedPreferences {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 //            val masterKeyAlias = MasterKey.Builder(context)
 //            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
 //                .build()
@@ -57,16 +57,20 @@ internal object RadarState {
 //                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
 //                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
 //            )
-            return EncryptedSharedPreferences.create(
-                "RadarState",
-                MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
-                context,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
-        } else {
-            return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
-        }
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                EncryptedSharedPreferences.create(
+                    "RadarState",
+                    MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+                    context,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                )
+            } else {
+                context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
+            }
+//        } else {
+//            return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
+//        }
     }
 
     // TODO: migration: pseudo code, attempt to check encoded version, if they do not have it, fall back to

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -54,9 +54,6 @@ internal object RadarState {
 
     }
 
-    // TODO: migration: pseudo code, attempt to check encoded version, if they do not have it, fall back to
-    // non encrypted version, before returning default. "eventual migration" just like in Segment.
-
     private fun getFloat(context: Context, key: String, default: Float): Float {
         return getEncryptedSharedPreferences(context).getFloat(key, getSharedPreferences(context).getFloat(key, default))
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
@@ -117,9 +117,6 @@ internal object RadarUtils {
     }
 
     internal fun isScreenSharing(context: Context): Boolean {
-        if (Build.VERSION.SDK_INT < 17) {
-            return false
-        }
         val displayManager = DisplayManagerCompat.getInstance(context)
         val multipleDisplays = displayManager.displays.size > 1
 

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -11,7 +11,6 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.play.core.integrity.IntegrityManagerFactory
 import io.radar.sdk.RadarUtils.hashSHA256
 
-@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal class RadarVerificationManager(
     private val context: Context,
     private val logger: RadarLogger,

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -1,20 +1,19 @@
 package io.radar.sdk
 
+import FakeAndroidKeyStore
 import android.content.Context
 import android.location.Location
-import android.net.Uri
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.radar.sdk.model.*
 import org.json.JSONObject
-import org.junit.Test
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
-import java.net.URL
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -271,6 +270,8 @@ class RadarTest {
 
         Radar.locationManager.locationClient = locationClientMock
         Radar.locationManager.permissionsHelper = permissionsHelperMock
+        FakeAndroidKeyStore.setup
+
     }
 
     @Test

--- a/sdk/src/test/java/io/radar/sdk/util/FakeAndroidKeyStore.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/FakeAndroidKeyStore.kt
@@ -1,0 +1,62 @@
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.Key
+import java.security.KeyStore
+import java.security.KeyStoreSpi
+import java.security.Provider
+import java.security.SecureRandom
+import java.security.Security
+import java.security.cert.Certificate
+import java.security.spec.AlgorithmParameterSpec
+import java.util.Date
+import java.util.Enumeration
+import javax.crypto.KeyGenerator
+import javax.crypto.KeyGeneratorSpi
+import javax.crypto.SecretKey
+
+object FakeAndroidKeyStore {
+
+    val setup by lazy {
+        Security.addProvider(object : Provider("AndroidKeyStore", 1.0, "") {
+            init {
+                put("KeyStore.AndroidKeyStore", FakeKeyStore::class.java.name)
+                put("KeyGenerator.AES", FakeAesKeyGenerator::class.java.name)
+            }
+        })
+    }
+
+    @Suppress("unused")
+    class FakeKeyStore : KeyStoreSpi() {
+        private val wrapped = KeyStore.getInstance(KeyStore.getDefaultType())
+
+        override fun engineIsKeyEntry(alias: String?): Boolean = wrapped.isKeyEntry(alias)
+        override fun engineIsCertificateEntry(alias: String?): Boolean = wrapped.isCertificateEntry(alias)
+        override fun engineGetCertificate(alias: String?): Certificate = wrapped.getCertificate(alias)
+        override fun engineGetCreationDate(alias: String?): Date = wrapped.getCreationDate(alias)
+        override fun engineDeleteEntry(alias: String?) = wrapped.deleteEntry(alias)
+        override fun engineSetKeyEntry(alias: String?, key: Key?, password: CharArray?, chain: Array<out Certificate>?) =
+            wrapped.setKeyEntry(alias, key, password, chain)
+
+        override fun engineSetKeyEntry(alias: String?, key: ByteArray?, chain: Array<out Certificate>?) = wrapped.setKeyEntry(alias, key, chain)
+        override fun engineStore(stream: OutputStream?, password: CharArray?) = wrapped.store(stream, password)
+        override fun engineSize(): Int = wrapped.size()
+        override fun engineAliases(): Enumeration<String> = wrapped.aliases()
+        override fun engineContainsAlias(alias: String?): Boolean = wrapped.containsAlias(alias)
+        override fun engineLoad(stream: InputStream?, password: CharArray?) = wrapped.load(stream, password)
+        override fun engineGetCertificateChain(alias: String?): Array<Certificate> = wrapped.getCertificateChain(alias)
+        override fun engineSetCertificateEntry(alias: String?, cert: Certificate?) = wrapped.setCertificateEntry(alias, cert)
+        override fun engineGetCertificateAlias(cert: Certificate?): String = wrapped.getCertificateAlias(cert)
+        override fun engineGetKey(alias: String?, password: CharArray?): Key? =
+            wrapped.getKey(alias, password)
+    }
+
+    @Suppress("unused")
+    class FakeAesKeyGenerator : KeyGeneratorSpi() {
+        private val wrapped = KeyGenerator.getInstance("AES")
+
+        override fun engineInit(random: SecureRandom?) = Unit
+        override fun engineInit(params: AlgorithmParameterSpec?, random: SecureRandom?) = Unit
+        override fun engineInit(keysize: Int, random: SecureRandom?) = Unit
+        override fun engineGenerateKey(): SecretKey = wrapped.generateKey()
+    }
+}


### PR DESCRIPTION
Decisions and considerations. We are adding a new android x dependency for encrypted shared preferences. We have decided to use the interface of the long term stable version, like Okta and Stripe. This implementation choice was picked over the alternative of using shared preference with in-house crypto library (high risk and engineering effort) and migrating off shared preferences (high effort).

Risk of dependency conflicts are mitigated via using a version of the dependency used by other SDKs and also  allowing devices running earlier versions of android to use the regular shared preferences. 


Currently implementing with bump in minimum deploy target to SDK 23. Based on data on customers, we determined that the impacts are small.

- only 0.4% of **all** historical users will be impacted
- If we only consider users that were active in the last year, there will be an even smaller impact. in particular:
-- there are only 2 customer who have more than 100 users that will be impacted.
-- the percentage of users impacted for each customer is about 0.2%.
  



Added a fake key store to pass unit test per suggestion of (this is a workaround and there does not seem to be an offical support for `AndroidKeyStore` within the test suite)

- https://stackoverflow.com/questions/38213748/using-the-android-keystore-in-robolectric-tests
- https://proandroiddev.com/testing-jetpack-security-with-robolectric-9f9cf2aa4f61
-https://github.com/robolectric/robolectric/issues/1518