### PR TITLE
Track verified callbacks

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,9 +1,4 @@
 # Migration guides
-## 3.11.x to 3.12.x
--`RadarReceiver` interface has been changed to include `onLocationPermissionStatusUpdated` method.
-
-## 3.9.x to 3.10.x
-- The `fun searchGeofences( radius: Int, tags: Array<String>?, metadata: JSONObject?, limit: Int?, callback: RadarSearchGeofencesCallback)` method is now `fun searchGeofences( radius: Int?, tags: Array<String>?, metadata: JSONObject?, limit: Int?, includeGeometry, Boolean?, callback: RadarSearchGeofencesCallback)`  and `fun searchGeofences( near:Location, radius: Int, tags: Array<String>?, metadata: JSONObject?, limit: Int?, callback: RadarSearchGeofencesCallback)` is now `fun searchGeofences( near:Location, radius: Int?, tags: Array<String>?, metadata: JSONObject?, limit: Int?, includeGeometry, Boolean?, callback: RadarSearchGeofencesCallback)`. `radius` is now optional and `includeGeometry` needs to be set if you wish your returned geofence objects to include the full geometry of polygon geofences.
 
 ## 3.12.x to 3.13.x
 -  The `Radar.trackVerified()` method now returns `token: RadarVerifiedLocationToken`, which includes `user`, `events`, `token,`, `expiresAt`, `expiresIn`, and `passed`. The `Radar.trackVerifiedToken()` method has been removed, since `Radar.trackVerified()` now returns a signed JWT.
@@ -33,6 +28,12 @@ Radar.trackVerifiedToken { status, token ->
   // send token to server for validation
 }
 ```
+
+## 3.11.x to 3.12.x
+- The `RadarReceiver` interface has been changed to add a `onLocationPermissionStatusUpdated()` method.
+
+## 3.9.x to 3.10.x
+- The `Radar.searchGeofences()` methods have been changed. Use `includeGeometry` to include full geometry of the geofence. Radius is now optional.
 
 ## 3.8.x to 3.9.x
 - The `Radar.autocomplete(query, near, layers, limit, country, expandUnits, callback)` method is now `Radar.autocomplete(query, near, layers, limit, country, expandUnits, mailable, callback)`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,10 +1,39 @@
 # Migration guides
 
-## 3.8.x to 3.9.0
+## 3.12.x to 3.13.x
+-  The `Radar.trackVerified()` method now returns `token: RadarVerifiedLocationToken`, which includes `user`, `events`, `token,`, `expiresAt`, `expiresIn`, and `passed`. The `Radar.trackVerifiedToken()` method has been removed, since `Radar.trackVerified()` now returns a signed JWT.
+
+```kotlin
+// 3.13.x
+Radar.trackVerified { (status, token) in
+  if (token?.passed == true) {
+    // allow access to feature, send token to server for validation
+  } else {
+    // deny access to feature, show error message
+  }
+}
+
+// 3.12.x
+Radar.trackVerified { status, location, events, user ->
+  if (user?.fraud?.passed == true &&
+    user.country?.allowed == true &&
+    user.state?.allowed == true) {
+    // allow access to feature
+  } else {
+    // deny access to feature, show error message
+  }
+}
+
+Radar.trackVerifiedToken { status, token ->
+  // send token to server for validation
+}
+```
+
+## 3.8.x to 3.9.x
 - The `Radar.autocomplete(query, near, layers, limit, country, expandUnits, callback)` method is now `Radar.autocomplete(query, near, layers, limit, country, expandUnits, mailable, callback)`.
   - `expandUnits` has been deprecated and will always be true regardless of value passed in.
 
-## 3.6.x to 3.7.0
+## 3.6.x to 3.7.x
 - Custom events have been renamed to conversions.
   - `Radar.sendEvent(customType, metadata, callback)` is now `Radar.logConversion(name, metadata, callback)`.
   - `Radar.logConversion(name, revenue, metadata, callback)` has been added.

--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -14,6 +14,7 @@ import io.radar.sdk.Radar
 import io.radar.sdk.RadarTrackingOptions
 import io.radar.sdk.RadarTripOptions
 import io.radar.sdk.RadarVerifiedReceiver
+import io.radar.sdk.model.RadarVerifiedLocationToken
 import org.json.JSONObject
 import java.util.EnumSet
 
@@ -30,8 +31,8 @@ class MainActivity : AppCompatActivity() {
         Radar.sdkVersion()?.let { Log.i("version", it) }
 
         val verifiedReceiver = object : RadarVerifiedReceiver() {
-            override fun onTokenUpdated(context: Context, token: String) {
-                Log.i("example", "Token updated to $token")
+            override fun onTokenUpdated(context: Context, token: RadarVerifiedLocationToken) {
+
             }
         }
         Radar.setVerifiedReceiver(verifiedReceiver)

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.13.0-beta.2'
+    radarVersion = '3.13.0'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.9.7'
+    radarVersion = '3.13.0-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.13.0-beta.1'
+    radarVersion = '3.13.0-beta.2'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -817,7 +817,7 @@ object Radar {
                             user: RadarUser?,
                             nearbyGeofences: Array<RadarGeofence>?,
                             config: RadarConfig?,
-                            token: String?
+                            token: RadarVerifiedLocationToken?
                         ) {
                             if (status == RadarStatus.SUCCESS ){
                                 locationManager.updateTrackingFromMeta(config?.meta)
@@ -914,7 +914,7 @@ object Radar {
                 user: RadarUser?,
                 nearbyGeofences: Array<RadarGeofence>?,
                 config: RadarConfig?,
-                token: String?
+                token: RadarVerifiedLocationToken?
             ) {
                 if (status == RadarStatus.SUCCESS ){
                     locationManager.updateTrackingFromMeta(config?.meta)
@@ -1171,7 +1171,7 @@ object Radar {
                                 user: RadarUser?,
                                 nearbyGeofences: Array<RadarGeofence>?,
                                 config: RadarConfig?,
-                                token: String?
+                                token: RadarVerifiedLocationToken?
                             ) {
                                 handler.post {
                                     callback?.onComplete(status, location, events, user)

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1459,8 +1459,6 @@ object Radar {
                 if (status == RadarStatus.SUCCESS) {
                     RadarSettings.setTripOptions(context, options)
 
-                    // store previous tracking options for post-trip
-                    // if tracking was false, previousTrackingOptions will be null
                     val isTracking = Radar.isTracking()
                     if (isTracking) {
                         val previousTrackingOptions = RadarSettings.getTrackingOptions(context)
@@ -1469,9 +1467,8 @@ object Radar {
                         RadarSettings.removePreviousTrackingOptions(context)
                     }
 
-                    // if trackingOptions provided, startTracking
                     if (trackingOptions != null) {
-                        Radar.startTracking(trackingOptions);
+                        Radar.startTracking(trackingOptions)
                     }
 
                     // flush location update to generate events
@@ -3272,8 +3269,7 @@ object Radar {
     internal fun loadReplayBufferFromSharedPreferences() {
         replayBuffer.loadFromSharedPreferences()
         val replayCount = replayBuffer.getSize()
-        // TODO: revisit this log
-        logger.d("loaded replay buffer from shared preferences with $replayCount replays")
+        logger.d("Loaded replays | replayCount = $replayCount")
     }
 
     @JvmStatic

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -90,7 +90,7 @@ object Radar {
     interface RadarTrackVerifiedCallback {
 
         /**
-         * Called when an track verified request succeeds, fails, or times out. Receives the request status and, if successful, the user's verified location. Verify the token server-side using your secret key.
+         * Called when a track verified request succeeds, fails, or times out. Receives the request status and, if successful, the user's verified location. Verify the token server-side using your secret key.
          *
          * @param[status] RadarStatus The request status.
          * @param[token] RadarVerifiedLocationToken? If successful, the user's verified location.

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -177,15 +177,10 @@ internal class RadarApiClient(
             },
             extendedTimeout = false,
             stream = true,
-            // Do not log the saved log events. If the logs themselves were logged it would create a redundancy and
-            // eventually lead to a crash when creating a downstream log request, since these will log to memory as a
-            // single log entry. Then each time after, this log entry would contain more and more logs, eventually
-            // causing an out of memory exception.
-            logPayload = false
+            logPayload = false // avoid logging the logging call
         )
     }
 
-    // api handler for /track/replay, just takes in a list of replays to send to API
     internal fun replay(replays: List<RadarReplay>, callback: RadarReplayApiCallback?) {
         val publishableKey = RadarSettings.getPublishableKey(context)
         if (publishableKey == null) {

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -611,7 +611,7 @@ internal class RadarLocationManager(
                     user: RadarUser?,
                     nearbyGeofences: Array<RadarGeofence>?,
                     config: RadarConfig?,
-                    token: String?
+                    token: RadarVerifiedLocationToken?
                 ) {
                     locationManager.replaceSyncedGeofences(nearbyGeofences)
 

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -554,7 +554,7 @@ internal class RadarLocationManager(
                 return
             }
 
-            // We add the 0.1 second buffer to account for the fact that the timer may fire slightly before the desired interval
+            // add a 0.1 second buffer to account for the fact that the timer may fire slightly before the desired interval
             val lastSyncIntervalWithBuffer = lastSyncInterval + 0.1
             if (lastSyncIntervalWithBuffer < options.desiredSyncInterval) {
                 logger.d("Skipping sync: desired sync interval | desiredSyncInterval = ${options.desiredSyncInterval}; lastSyncInterval = ${lastSyncIntervalWithBuffer}")

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -303,7 +303,7 @@ internal object RadarSettings {
     fun getFeatureSettings(context: Context): RadarFeatureSettings {
         val sharedPrefFeatureSettings = getSharedPreferences(context).getString(KEY_FEATURE_SETTINGS, null)
         try {
-            Radar.logger.d("getFeatureSettings | featureSettings = $sharedPrefFeatureSettings")
+            Radar.logger.d("Getting feature settings | featureSettings = $sharedPrefFeatureSettings")
         } catch (e: Exception) {
 
         }

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -84,7 +84,7 @@ internal object RadarSettings {
 
         val settings = RadarSettings.getFeatureSettings(context)
         if (settings.extendFlushReplays) {
-            Radar.logger.d("Flushing replays from updateSessionId")
+            Radar.logger.d("Flushing replays from updateSessionId()")
             Radar.flushReplays()
         }
 
@@ -231,7 +231,6 @@ internal object RadarSettings {
     internal fun setNotificationOptions(context:Context,notificationOptions:RadarNotificationOptions){
         val notificationOptionsJson = notificationOptions.toJson().toString()
         getSharedPreferences(context).edit { putString(KEY_NOTIFICATION_OPTIONS, notificationOptionsJson) }
-        // Update foregroundServiceOptions as well.
         var previousValue = getForegroundService(context)
         setForegroundService(context,RadarTrackingOptions.RadarTrackingOptionsForegroundService(
             previousValue.text,
@@ -270,7 +269,7 @@ internal object RadarSettings {
         context: Context,
         foregroundService: RadarTrackingOptions.RadarTrackingOptionsForegroundService
     ) {
-        // Previous values of iconColor and iconString are preserved if new fields are null.
+        // previous values of iconColor and iconString are preserved if new fields are null
         val previousValue = getForegroundService(context)
         if (foregroundService.iconString == null) {
            foregroundService.iconString = previousValue.iconString 
@@ -303,12 +302,10 @@ internal object RadarSettings {
 
     fun getFeatureSettings(context: Context): RadarFeatureSettings {
         val sharedPrefFeatureSettings = getSharedPreferences(context).getString(KEY_FEATURE_SETTINGS, null)
-        // The log buffer singleton is initialized before the logger, but requires calling this method
-        // to obtain its feature flag. Thus we cannot call the logger yet as its not yet initialized.
         try {
             Radar.logger.d("getFeatureSettings | featureSettings = $sharedPrefFeatureSettings")
         } catch (e: Exception) {
-            // Do nothing for now
+
         }
         val optionsJson = sharedPrefFeatureSettings ?: return RadarFeatureSettings.default()
         return RadarFeatureSettings.fromJson(JSONObject(optionsJson))

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -228,11 +228,11 @@ internal class RadarVerificationManager(
 
                         // if expiresIn is shorter than interval, override interval
                         minInterval = minOf(it.expiresIn, interval)
+                    }
 
-                        // re-request early to maximize the likelihood that a cached token is available
-                        if (minInterval > 20) {
-                            minInterval -= 10
-                        }
+                    // re-request early to maximize the likelihood that a cached token is available
+                    if (minInterval > 20) {
+                        minInterval -= 10
                     }
 
                     if (verificationManager.scheduled) {

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -51,6 +51,7 @@ internal class RadarVerificationManager(
 
     fun trackVerified(beacons: Boolean = false, callback: Radar.RadarTrackVerifiedCallback? = null) {
         val verificationManager = this
+        val lastTokenBeacons = beacons
 
         val usage = "trackVerified"
         Radar.apiClient.getConfig(usage, true, object : RadarApiClient.RadarGetConfigApiCallback {
@@ -115,6 +116,11 @@ internal class RadarVerificationManager(
                                                     Radar.locationManager.updateTrackingFromMeta(
                                                         config?.meta
                                                     )
+                                                }
+                                                if (token != null) {
+                                                    verificationManager.lastToken = token
+                                                    verificationManager.lastTokenElapsedRealtime = SystemClock.elapsedRealtime()
+                                                    verificationManager.lastTokenBeacons = lastTokenBeacons
                                                 }
                                                 Radar.handler.post {
                                                     callback?.onComplete(

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -294,7 +294,7 @@ internal class RadarVerificationManager(
         networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 super.onAvailable(network)
-                verificationManager.logger.d("Network connected | ips = $ips")
+                verificationManager.logger.d("Network connected")
                 handleNetworkChange()
             }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -8,6 +8,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import android.os.Handler
+import android.os.SystemClock
 import androidx.annotation.RequiresApi
 import com.google.android.play.core.integrity.StandardIntegrityManager
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityToken
@@ -20,7 +21,11 @@ import io.radar.sdk.model.RadarConfig
 import io.radar.sdk.model.RadarEvent
 import io.radar.sdk.model.RadarGeofence
 import io.radar.sdk.model.RadarUser
+import io.radar.sdk.model.RadarVerifiedLocationToken
 import org.json.JSONObject
+import java.net.InetAddress
+import java.net.NetworkInterface
+import java.util.Enumeration
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal class RadarVerificationManager(
@@ -32,12 +37,19 @@ internal class RadarVerificationManager(
     private var lastWarmUpTimestampSeconds = 0L
     private val handler = Handler(this.context.mainLooper)
     private val connectivityManager = this.context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    private var started = false
+    private var scheduled = false
+    private var lastToken: RadarVerifiedLocationToken? = null
+    private var lastTokenElapsedRealtime: Long = 0L
+    private var lastTokenBeacons: Boolean = false
+    private var lastIPs: String? = null
 
     internal companion object {
         private const val WARM_UP_WINDOW_SECONDS = 3600 * 12 // 12 hours
     }
 
-    fun trackVerified(beacons: Boolean = false, callback: Radar.RadarTrackCallback? = null) {
+    fun trackVerified(beacons: Boolean = false, callback: Radar.RadarTrackVerifiedCallback? = null) {
         val verificationManager = this
 
         val usage = "trackVerified"
@@ -97,7 +109,7 @@ internal class RadarVerificationManager(
                                                 user: RadarUser?,
                                                 nearbyGeofences: Array<RadarGeofence>?,
                                                 config: RadarConfig?,
-                                                token: String?
+                                                token: RadarVerifiedLocationToken?
                                             ) {
                                                 if (status == Radar.RadarStatus.SUCCESS) {
                                                     Radar.locationManager.updateTrackingFromMeta(
@@ -107,9 +119,7 @@ internal class RadarVerificationManager(
                                                 Radar.handler.post {
                                                     callback?.onComplete(
                                                         status,
-                                                        location,
-                                                        events,
-                                                        user
+                                                        token
                                                     )
                                                 }
                                             }
@@ -192,159 +202,55 @@ internal class RadarVerificationManager(
         })
     }
 
-    fun trackVerifiedToken(beacons: Boolean = false, callback: Radar.RadarTrackTokenCallback? = null) {
+    fun startTrackingVerified(interval: Int, beacons: Boolean) {
         val verificationManager = this
 
-        val usage = "trackVerifiedToken"
-        Radar.apiClient.getConfig(usage, true, object : RadarApiClient.RadarGetConfigApiCallback {
-            override fun onComplete(status: Radar.RadarStatus, config: RadarConfig) {
-                val googlePlayProjectNumber = config.googlePlayProjectNumber
+        verificationManager.started = true
+        verificationManager.scheduled = false
 
-                if (status != Radar.RadarStatus.SUCCESS) {
-                    Radar.handler.post {
-                        callback?.onComplete(status)
+        val trackVerified = { ->
+            verificationManager.trackVerified(beacons, object : Radar.RadarTrackVerifiedCallback {
+                override fun onComplete(
+                    status: Radar.RadarStatus,
+                    token: RadarVerifiedLocationToken?
+                ) {
+                    var expiresIn = 0
+                    var minInterval: Int = interval
+
+                    token?.let {
+                        expiresIn = it.expiresIn
+
+                        // if expiresIn is shorter than interval, override interval
+                        minInterval = minOf(it.expiresIn, interval)
+
+                        // re-request early to maximize the likelihood that a cached token is available
+                        if (minInterval > 20) {
+                            minInterval -= 10
+                        }
                     }
 
-                    return
+                    if (verificationManager.scheduled) {
+                        verificationManager.logger.d("Token request already scheduled")
 
-                }
+                        return
+                    }
 
-                Radar.locationManager.getLocation(
-                    RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH,
-                    Radar.RadarLocationSource.FOREGROUND_LOCATION,
-                    object :
-                        Radar.RadarLocationCallback {
-                        override fun onComplete(
-                            status: Radar.RadarStatus,
-                            location: Location?,
-                            stopped: Boolean
-                        ) {
-                            if (status != Radar.RadarStatus.SUCCESS || location == null) {
-                                Radar.handler.post {
-                                    callback?.onComplete(status)
-                                }
+                    verificationManager.logger.d("Requesting token again in $minInterval seconds | minInterval = $minInterval; expiresIn = $expiresIn; interval = $interval")
 
-                                return
-                            }
+                    verificationManager.scheduled = true
 
-                            val requestHash = verificationManager.getRequestHash(location)
+                    handler.postDelayed({
+                        if (verificationManager.started) {
+                            verificationManager.logger.d("Token request interval fired")
 
-                            verificationManager.getIntegrityToken(
-                                googlePlayProjectNumber,
-                                requestHash
-                            ) { integrityToken, integrityException ->
-                                val callTrackApi = { beacons: Array<RadarBeacon>? ->
-                                    Radar.apiClient.track(
-                                        location,
-                                        RadarState.getStopped(verificationManager.context),
-                                        RadarActivityLifecycleCallbacks.foreground,
-                                        Radar.RadarLocationSource.FOREGROUND_LOCATION,
-                                        false,
-                                        beacons,
-                                        true,
-                                        integrityToken,
-                                        integrityException,
-                                        true,
-                                        object : RadarApiClient.RadarTrackApiCallback {
-                                            override fun onComplete(
-                                                status: Radar.RadarStatus,
-                                                res: JSONObject?,
-                                                events: Array<RadarEvent>?,
-                                                user: RadarUser?,
-                                                nearbyGeofences: Array<RadarGeofence>?,
-                                                config: RadarConfig?,
-                                                token: String?
-                                            ) {
-                                                if (status == Radar.RadarStatus.SUCCESS) {
-                                                    Radar.locationManager.updateTrackingFromMeta(
-                                                        config?.meta
-                                                    )
-                                                }
-                                                Radar.handler.post {
-                                                    callback?.onComplete(status, token)
-                                                }
-                                            }
-                                        })
-                                }
+                            trackVerified()
 
-                                if (beacons && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                                    Radar.apiClient.searchBeacons(
-                                        location,
-                                        1000,
-                                        10,
-                                        object : RadarApiClient.RadarSearchBeaconsApiCallback {
-                                            override fun onComplete(
-                                                status: Radar.RadarStatus,
-                                                res: JSONObject?,
-                                                beacons: Array<RadarBeacon>?,
-                                                uuids: Array<String>?,
-                                                uids: Array<String>?
-                                            ) {
-                                                if (!uuids.isNullOrEmpty() || !uids.isNullOrEmpty()) {
-                                                    Radar.beaconManager.startMonitoringBeaconUUIDs(
-                                                        uuids,
-                                                        uids
-                                                    )
-
-                                                    Radar.beaconManager.rangeBeaconUUIDs(
-                                                        uuids,
-                                                        uids,
-                                                        false,
-                                                        object : Radar.RadarBeaconCallback {
-                                                            override fun onComplete(
-                                                                status: Radar.RadarStatus,
-                                                                beacons: Array<RadarBeacon>?
-                                                            ) {
-                                                                if (status != Radar.RadarStatus.SUCCESS || beacons == null) {
-                                                                    callTrackApi(null)
-
-                                                                    return
-                                                                }
-
-                                                                callTrackApi(beacons)
-                                                            }
-                                                        })
-                                                } else if (beacons != null) {
-                                                    Radar.beaconManager.startMonitoringBeacons(
-                                                        beacons
-                                                    )
-
-                                                    Radar.beaconManager.rangeBeacons(
-                                                        beacons,
-                                                        false,
-                                                        object : Radar.RadarBeaconCallback {
-                                                            override fun onComplete(
-                                                                status: Radar.RadarStatus,
-                                                                beacons: Array<RadarBeacon>?
-                                                            ) {
-                                                                if (status != Radar.RadarStatus.SUCCESS || beacons == null) {
-                                                                    callTrackApi(null)
-
-                                                                    return
-                                                                }
-
-                                                                callTrackApi(beacons)
-                                                            }
-                                                        })
-                                                } else {
-                                                    callTrackApi(arrayOf())
-                                                }
-                                            }
-                                        },
-                                        false
-                                    )
-                                } else {
-                                    callTrackApi(null)
-                                }
-                            }
+                            verificationManager.scheduled = false
                         }
-                    })
-            }
-        })
-    }
-
-    fun startTrackingVerified(token: Boolean, interval: Int, beacons: Boolean) {
-        val verificationManager = this
+                    }, minInterval.toLong())
+                }
+            })
+        }
 
         val request = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
@@ -354,16 +260,31 @@ internal class RadarVerificationManager(
             .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
             .build()
 
-        connectivityManager.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
+        networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 super.onAvailable(network)
 
-                verificationManager.logger.d("Network connected")
+                val ips = verificationManager.getIPs()
+                var changed = false
 
-                if (token) {
-                    verificationManager.trackVerifiedToken(beacons)
+                verificationManager.logger.d("Network connected | ips = $ips")
+
+                if (verificationManager.lastIPs == null) {
+                    verificationManager.logger.d("First time getting IPs")
+                    changed = false
+                } else if (ips == "error") {
+                    verificationManager.logger.d("Error getting IPs")
+                    changed = true
+                } else if (ips != verificationManager.lastIPs) {
+                    verificationManager.logger.d("IPs changed | ips = $ips; lastIPs = ${verificationManager.lastIPs}")
+                    changed = true
                 } else {
-                    verificationManager.trackVerified(beacons)
+                    verificationManager.logger.d("IPs unchanged")
+                }
+                verificationManager.lastIPs = ips
+
+                if (changed) {
+                    trackVerified()
                 }
             }
 
@@ -372,19 +293,45 @@ internal class RadarVerificationManager(
 
                 verificationManager.logger.d("Network lost")
             }
-        })
+        }
 
-        handler.post(object : Runnable {
-            override fun run() {
-                if (token) {
-                    verificationManager.trackVerifiedToken(beacons)
-                } else {
-                    verificationManager.trackVerified(beacons)
+        networkCallback?.let {
+            connectivityManager.registerNetworkCallback(request, it)
+        }
+
+        trackVerified()
+    }
+
+    fun stopTrackingVerified() {
+        this.started = false
+
+        networkCallback?.let {
+            connectivityManager.unregisterNetworkCallback(it)
+        }
+    }
+
+    fun getVerifiedLocationToken(callback: Radar.RadarTrackVerifiedCallback? = null) {
+        val lastTokenElapsed = (SystemClock.elapsedRealtime() - this.lastTokenElapsedRealtime) / 1000
+
+        if (this.lastToken != null) {
+            this.lastToken?.let {
+                if (lastTokenElapsed < it.expiresIn) {
+                    Radar.logger.d("Last token valid | lastToken.expiresIn = ${it.expiresIn}; lastTokenElapsed = $lastTokenElapsed")
+
+                    Radar.flushLogs()
+
+                    callback?.onComplete(Radar.RadarStatus.SUCCESS, it)
+
+                    return
                 }
 
-                handler.postDelayed(this, interval * 1000L)
+                Radar.logger.d("Last token invalid | lastToken.expiresIn = ${it.expiresIn}; lastTokenElapsed = $lastTokenElapsed")
             }
-        })
+        } else {
+            Radar.logger.d("No last token")
+        }
+
+        this.trackVerified(this.lastTokenBeacons, callback)
     }
 
     fun getRequestHash(location: Location): String {
@@ -475,6 +422,33 @@ internal class RadarVerificationManager(
                 
                 block(null, integrityException)
             }
+    }
+
+    fun getIPs(): String {
+        val ips = mutableListOf<String>()
+
+        try {
+            val interfaces: Enumeration<NetworkInterface> = NetworkInterface.getNetworkInterfaces()
+            while (interfaces.hasMoreElements()) {
+                val networkInterface: NetworkInterface = interfaces.nextElement()
+                val addresses: Enumeration<InetAddress> = networkInterface.inetAddresses
+
+                while (addresses.hasMoreElements()) {
+                    val address: InetAddress = addresses.nextElement()
+                    address.hostAddress?.let { ips.add(it) }
+                }
+            }
+        } catch (e: Exception) {
+            logger.d("Error getting IPs | e = ${e.localizedMessage}")
+
+            return "error"
+        }
+
+        if (ips.size > 0) {
+            return ips.joinToString(",")
+        }
+
+        return "error"
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -245,15 +245,17 @@ internal class RadarVerificationManager(
 
                     verificationManager.scheduled = true
 
-                    handler.postDelayed({
-                        if (verificationManager.started) {
-                            verificationManager.logger.d("Token request interval fired")
+                    handler.postDelayed(object : Runnable {
+                        override fun run() {
+                            if (verificationManager.started) {
+                                verificationManager.logger.d("Token request interval fired")
 
-                            trackVerified()
+                                trackVerified()
 
-                            verificationManager.scheduled = false
+                                verificationManager.scheduled = false
+                            }
                         }
-                    }, minInterval.toLong())
+                    }, minInterval * 1000L)
                 }
             })
         }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
@@ -1,19 +1,20 @@
 package io.radar.sdk
 
 import android.content.Context
+import io.radar.sdk.model.RadarVerifiedLocationToken
 
 /**
- * A receiver for client-side delivery of verified location tokens. For more information, see [](https://radar.com/documentation/fraud).
+ * A delegate for client-side delivery of verified location tokens. For more information, see [](https://radar.com/documentation/fraud).
  *
  * @see [](https://radar.com/documentation/fraud)
  */
 abstract class RadarVerifiedReceiver {
 
     /**
-     * Tells the delegate that the current user's verified location was updated. Receives a JSON Web Token (JWT). Verify the JWT server-side using your secret key.
+     * Tells the delegate that the current user's verified location was updated. Verify the token server-side using your secret key.
      *
      * @param[token] The token.
      */
-    abstract fun onTokenUpdated(context: Context, token: String)
+    abstract fun onTokenUpdated(context: Context, token: RadarVerifiedLocationToken)
 
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import io.radar.sdk.model.RadarVerifiedLocationToken
 
 /**
- * A delegate for client-side delivery of verified location tokens. For more information, see [](https://radar.com/documentation/fraud).
+ * A receiver for client-side delivery of verified location tokens. For more information, see [](https://radar.com/documentation/fraud).
  *
  * @see [](https://radar.com/documentation/fraud)
  */
 abstract class RadarVerifiedReceiver {
 
     /**
-     * Tells the delegate that the current user's verified location was updated. Verify the token server-side using your secret key.
+     * Tells the receiver that the current user's verified location was updated. Verify the token server-side using your secret key.
      *
      * @param[token] The token.
      */

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -228,7 +228,6 @@ class RadarEvent(
             val createdAt = RadarUtils.isoStringToDate(obj.optString(FIELD_CREATED_AT)) ?: Date()
             val actualCreatedAt = RadarUtils.isoStringToDate(obj.optString(FIELD_ACTUAL_CREATED_AT)) ?: Date()
             val live = obj.optBoolean(FIELD_LIVE)
-            // These strings should match the values (and order) of the server's event constants.
             val type = when (obj.optString(FIELD_TYPE)) {
                 "user.entered_geofence" -> USER_ENTERED_GEOFENCE
                 "user.exited_geofence" -> USER_EXITED_GEOFENCE

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -116,7 +116,6 @@ class RadarEvent(
      * The types for events.
      */
     enum class RadarEventType {
-        // These strings should match the values (and order) of the server's event constants.
         /** Unknown */
         UNKNOWN,
         /** A conversion event, logged with Radar.logConversion() */
@@ -329,7 +328,6 @@ class RadarEvent(
         @JvmStatic
         fun stringForType(type: RadarEventType): String? {
             return when (type) {
-                // These strings should match the values (and order) of the server's event constants.
                 USER_ENTERED_GEOFENCE -> "user.entered_geofence"
                 USER_EXITED_GEOFENCE -> "user.exited_geofence"
                 USER_DWELLED_IN_GEOFENCE -> "user.dwelled_in_geofence"

--- a/sdk/src/main/java/io/radar/sdk/model/RadarGeofence.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarGeofence.kt
@@ -179,8 +179,6 @@ class RadarGeofence(
                     obj.putOpt(FIELD_GEOMETRY_CENTER, geometry.center.toJson())
                     obj.putOpt(FIELD_GEOMETRY_RADIUS, geometry.radius)
                     if (geometry.coordinates != null) {
-                        /* Nest coordinate array; Per GeoJSON spec: for type "Polygon", the
-                        "coordinates" member must be an array of LinearRing coordinate arrays. */
                         val geometryCoordinates = JSONArray()
                         geometryCoordinates.put(toJson(geometry.coordinates))
                         obj.putOpt(FIELD_COORDINATES, geometryCoordinates)

--- a/sdk/src/main/java/io/radar/sdk/model/RadarReplay.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarReplay.kt
@@ -14,7 +14,6 @@ import org.json.JSONObject
     companion object {
         private const val REPLAY_PARAMS = "replayParams"
 
-        // does this make sense?
         @JvmStatic
         fun fromJson(json: JSONObject): RadarReplay {
             return RadarReplay(
@@ -23,7 +22,6 @@ import org.json.JSONObject
         }
     }
 
-    // does this make sense as well?
     fun toJson(): JSONObject {
         return JSONObject().apply {
             putOpt(REPLAY_PARAMS, replayParams)

--- a/sdk/src/main/java/io/radar/sdk/model/RadarVerifiedLocationToken.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarVerifiedLocationToken.kt
@@ -1,0 +1,82 @@
+package io.radar.sdk.model
+
+import io.radar.sdk.RadarUtils
+import org.json.JSONObject
+import java.util.Date
+
+/**
+ * Represents a user's verified location.
+ *
+ * @see [](https://radar.com/documentation/fraud)
+ */
+class RadarVerifiedLocationToken(
+    /**
+     * The user.
+     */
+    val user: RadarUser,
+
+    /**
+     * An array of events.
+     */
+    val events: Array<RadarEvent>,
+
+    /**
+     * A signed JSON Web Token (JWT) containing the user and array of events. Verify the token server-side using your secret key.
+     */
+    val token: String,
+
+    /**
+     * The datetime when the token expires.
+     */
+    val expiresAt: Date,
+
+    /**
+     * The number of seconds until the token expires.
+     */
+    val expiresIn: Int,
+
+    /**
+     * A boolean indicating whether the user passed all jurisdiction and fraud detection checks.
+     */
+    val passed: Boolean
+) {
+    internal companion object {
+        private const val FIELD_USER = "user"
+        private const val FIELD_EVENTS = "events"
+        private const val FIELD_TOKEN = "token"
+        private const val FIELD_EXPIRES_AT = "expiresAt"
+        private const val FIELD_EXPIRES_IN = "expiresIn"
+        private const val FIELD_PASSED = "passed"
+
+        fun fromJson(obj: JSONObject?): RadarVerifiedLocationToken? {
+            if (obj == null) {
+                return null
+            }
+
+            val user: RadarUser? = RadarUser.fromJson(obj.optJSONObject(FIELD_USER))
+            val events: Array<RadarEvent>? = RadarEvent.fromJson(obj.optJSONArray(FIELD_EVENTS))
+            val token: String? = obj.optString(FIELD_TOKEN)
+            val expiresAt: Date? = RadarUtils.isoStringToDate(obj.optString(FIELD_EXPIRES_AT))
+            val expiresIn: Int = obj.optInt(FIELD_EXPIRES_IN)
+            val passed: Boolean = user?.fraud?.passed == true && user.country?.passed == true && user.state?.passed == true
+
+            if (user == null || events == null || token == null || expiresAt == null) {
+                return null
+            }
+
+            return RadarVerifiedLocationToken(user, events, token, expiresAt, expiresIn, passed)
+        }
+    }
+
+    fun toJson(): JSONObject {
+        val obj = JSONObject()
+        obj.putOpt(FIELD_USER, this.user.toJson())
+        obj.putOpt(FIELD_EVENTS, RadarEvent.toJson(this.events))
+        obj.putOpt(FIELD_TOKEN, this.token)
+        obj.putOpt(FIELD_EXPIRES_AT, RadarUtils.dateToISOString(this.expiresAt))
+        obj.putOpt(FIELD_EXPIRES_IN, this.expiresIn)
+        obj.putOpt(FIELD_PASSED, this.passed)
+        return obj
+    }
+
+}

--- a/sdk/src/main/java/io/radar/sdk/util/BatteryState.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/BatteryState.kt
@@ -3,9 +3,6 @@ package io.radar.sdk.util
 import android.os.PowerManager
 import io.radar.sdk.RadarBatteryManager
 
-/**
- * Contains information about the battery state
- */
 internal data class BatteryState(
     val isCharging: Boolean,
     val percent: Float,
@@ -15,12 +12,6 @@ internal data class BatteryState(
     val isDeviceIdleMode: Boolean
 ) {
 
-    /**
-     * The performance state. This uses Android's [PowerManager] to gather information
-     * about the current optimization settings that could affect the SDK's performance, and returns
-     * a simplified status which identifies whether or not battery optimizations may be affecting
-     * the SDK's responsiveness.
-     */
     val performanceState: PerformanceState
 
     init {
@@ -31,20 +22,16 @@ internal data class BatteryState(
                 isDeviceIdleMode -> {
                     performanceState = if (isAffectedByPowerSaver) {
                         if (isLocationAffectedByPowerSaver) {
-                            // Idle, with power saver and location throttled
                             PerformanceState.LOWEST
                         } else {
-                            // Idle with Power Saver
                             PerformanceState.LOW
                         }
                     } else {
-                        // Idle Only
                         PerformanceState.IDLE
                     }
                 }
                 isAffectedByPowerSaver -> {
                     performanceState = if (isLocationAffectedByPowerSaver) {
-                        // Optimized And Location Throttled
                         PerformanceState.LOCATIONS_LOW_PERFORMANCE
                     } else {
                         PerformanceState.OPTIMIZED
@@ -59,10 +46,6 @@ internal data class BatteryState(
         }
     }
 
-    /**
-     * Get the string value for the current location power saving mode
-     * @see [PowerManager.getLocationPowerSaveMode]
-     */
     fun getPowerLocationPowerSaveModeString() : String {
         return when(locationPowerSaveMode) {
             0 -> "LOCATION_MODE_NO_CHANGE"
@@ -75,39 +58,11 @@ internal data class BatteryState(
     }
 
     internal enum class PerformanceState {
-
-        /**
-         * No performance optimizations are in affect, or the app is exempt
-         */
         OK,
-
-        /**
-         * Performance Mode is optimized. Location settings for performance mode are either
-         * fully allowed, or device does not support more granular performance settings.
-         */
         OPTIMIZED,
-
-        /**
-         * Performance Mode is optimized, and location polling is affected by it.
-         */
         LOCATIONS_LOW_PERFORMANCE,
-
-        /**
-         * Device is in an Idle state, and performance mode is not optimized.
-         */
         IDLE,
-
-        /**
-         * Device is Idle and performance is optimized. Location settings for performance mode are either
-         * fully allowed, or device does not support more granular performance settings.
-         */
         LOW,
-
-        /**
-         * Device is idle, performance is optimized, and location polling is affected by the performance
-         * optimization.
-         */
         LOWEST
-
     }
 }

--- a/sdk/src/main/java/io/radar/sdk/util/Flushable.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/Flushable.kt
@@ -5,4 +5,5 @@ internal interface Flushable<T> {
     fun get(): List<T>
 
     fun onFlush(success: Boolean)
+
 }

--- a/sdk/src/main/java/io/radar/sdk/util/JobMapper.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/JobMapper.kt
@@ -22,8 +22,8 @@ internal class JobMapper {
         private set
 
     /**
-     * Get the next-available Job ID. This uses the given [maxConcurrentJobs] to adjust the number of available Job
-     * IDs, as needed. It returns the next empty Job ID (ie, where its counter is equal to zero). If no such Job ID
+     * Get the next available Job ID. This uses the given [maxConcurrentJobs] to adjust the number of available Job
+     * IDs, as needed. It returns the next empty Job ID (i.e., where its counter is equal to zero). If no such Job ID
      * is available, it clears the highest counter and returns the associated Job ID.
      */
     fun getJobId(maxConcurrentJobs: Int): Int {
@@ -41,7 +41,7 @@ internal class JobMapper {
             counter[key] = 0
             key
         } else {
-            // Overwrites the longest-scheduled-job
+            // overwrites the longest scheduled job
             val entry = counter.maxByOrNull { it.value }!!
             counter[entry.key] = 0
             entry.key
@@ -55,7 +55,7 @@ internal class JobMapper {
     @VisibleForTesting
     fun adjustSize(maxConcurrentJobs: Int) {
         if (size > maxConcurrentJobs) {
-            // Less jobs available
+            // less jobs available
             for (i in size until maxConcurrentJobs) {
                 counter.remove(DEFAULT_JOB_ID + i)
             }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarFileStorage.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarFileStorage.kt
@@ -1,4 +1,5 @@
 package io.radar.sdk.util
+
 import android.content.Context
 import java.io.File
 import java.io.FileInputStream

--- a/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarLogBuffer.kt
@@ -9,12 +9,6 @@ internal interface RadarLogBuffer {
 
     abstract val context: Context
 
-    /**
-     * Write a log to the buffer
-     *
-     * @param[level] log level
-     * @param[message] log message
-     */
     fun write(
         level: Radar.RadarLogLevel,
         type: Radar.RadarLogType?,
@@ -22,12 +16,6 @@ internal interface RadarLogBuffer {
         createdAt: Date = Date()
     )
 
-    /**
-     * Creates a stash of the logs currently in the buffer and returns them as a [Flushable] so that a successful
-     * callback can cleanup this log buffer by deleting old log files.
-     *
-     * @return a [Flushable] containing all stored logs
-     */
     fun getFlushableLogs(): Flushable<RadarLog>
 
     /**

--- a/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
@@ -1,28 +1,14 @@
 package io.radar.sdk.util
 
-import io.radar.sdk.Radar
 import io.radar.sdk.model.RadarReplay
 import org.json.JSONObject
 
 internal interface RadarReplayBuffer {
 
-    /**
-     * Get the size of the current replay buffer
-     */
     fun getSize(): Int
 
-    /**
-     * Write an element to the buffer
-     *
-     */
     fun write(replayParams: JSONObject)
 
-    /**
-     * Creates a stash of the replays currently in the buffer and returns them as a [Flushable] so that a successful
-     * callback can cleanup this replay buffer by deleting replays that have been flushed.
-     *
-     * @return a [Flushable] containing all stored replays
-     */
     fun getFlushableReplaysStash(): Flushable<RadarReplay>
 
     fun loadFromSharedPreferences()

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleLogBuffer.kt
@@ -13,11 +13,7 @@ import java.util.Date
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-/**
- * Log Buffer implementation that is backed by an in-memory buffer and files on disk.
- */
-internal class
-RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer {
+internal class RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer {
 
     private companion object {
 
@@ -127,9 +123,6 @@ RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer {
         return logs
     }
 
-    /**
-     * Writes logs to disk.
-     */
     private fun writeToFileStorage(logs: Collection<RadarLog>) {
         for (log in logs) {
             val counterString = String.format("%04d", fileCounter++)
@@ -137,7 +130,6 @@ RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer {
             RadarFileStorage(context).writeData(logFileDir, fileName, log.toJson().toString())
         }
     }
-
 
     override fun getFlushableLogs(): Flushable<RadarLog> {
         val logs = mutableListOf<RadarLog>()
@@ -179,10 +171,6 @@ RadarSimpleLogBuffer(override val context: Context): RadarLogBuffer {
         }
     }
 
-
-    /**
-     * Clears oldest logs and adds a "purged" log line.
-     */
     private fun purgeOldestLogs() {
         if (persistentLogFeatureFlag) {
             var files = getLogFilesInTimeOrder()

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
@@ -1,6 +1,5 @@
 package io.radar.sdk.util
 
-import io.radar.sdk.Radar
 import io.radar.sdk.RadarSettings
 import io.radar.sdk.model.RadarReplay
 import android.content.Context
@@ -9,10 +8,6 @@ import androidx.core.content.edit
 import java.util.concurrent.LinkedBlockingDeque
 import org.json.JSONObject
 import org.json.JSONArray
-
-/**
- * A buffer for replay events.
- */
 
 internal class RadarSimpleReplayBuffer(private val context: Context) : RadarReplayBuffer {
 
@@ -35,7 +30,7 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
         buffer.offer(RadarReplay(replayParams))
         val featureSettings = RadarSettings.getFeatureSettings(context)
         if (featureSettings.usePersistence) {
-            // If buffer length is above 50, remove every fifth replay from the persisted buffer 
+            // if buffer length is above 50, remove every fifth replay from the persisted buffer
             if (buffer.size > 50) {
                 val prunedBuffer = buffer.filterIndexed { index, _ -> index % 5 != 0 }
                 val prunedReplaysAsJsonArray = JSONArray(prunedBuffer.map { it.toJson() })


### PR DESCRIPTION
Android equivalent of https://github.com/radarlabs/radar-sdk-ios/pull/337

- Remove `trackVerifiedToken()` and change `trackVerified()` to return `RadarVerifiedLocationToken`
- Remove `token` param from `startTrackingVerified()` and change `RadarVerifiedDelegate` to return `RadarVerifiedLocationToken`
- Make `token.expiresAt` override `interval` if needed
- Add `getVerifiedLocationToken()` which will return last token if not expired and request fresh token if needed
- Random logging and comment cleanup to match iOS