### PR TITLE
allow 0 importance for radar foreground service

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.18.2'
+    radarVersion = '3.18.3'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarForegroundService.kt
@@ -55,13 +55,12 @@ class RadarForegroundService : Service() {
         manager.deleteNotificationChannel("RadarSDK")
         var id = extras?.getInt("id") ?: 0
         id = if (id == 0) NOTIFICATION_ID else id
-        var importance = extras?.getInt("importance") ?: 0
-        importance = if (importance == 0) NotificationManager.IMPORTANCE_DEFAULT else importance
+        val importance = extras?.getInt("importance", NotificationManager.IMPORTANCE_DEFAULT) ?: NotificationManager.IMPORTANCE_DEFAULT
         val title = extras?.getString("title")
         val text = extras?.getString("text") ?: "Location tracking started"
-        var icon = extras?.getInt("icon") ?: 0
-        var iconString = extras?.getString("iconString") ?: this.applicationInfo.icon.toString()
-        var iconColor = extras?.getString("iconColor") ?: ""
+        val icon = extras?.getInt("icon") ?: 0
+        val iconString = extras?.getString("iconString") ?: this.applicationInfo.icon.toString()
+        val iconColor = extras?.getString("iconColor") ?: ""
         var smallIcon = resources.getIdentifier(iconString, "drawable", applicationContext.packageName) 
         if (icon != 0){
            smallIcon = resources.getIdentifier(icon.toString(), "drawable", applicationContext.packageName)  
@@ -74,7 +73,7 @@ class RadarForegroundService : Service() {
             .setContentText(text as CharSequence?)
             .setOngoing(true)
             .setSmallIcon(smallIcon)
-        if (title != null && title.isNotEmpty()) {
+        if (!title.isNullOrEmpty()) {
             builder = builder.setContentTitle(title as CharSequence?)
         }
         if (iconColor.isNotEmpty()) {


### PR DESCRIPTION
tested with example app that passing in importance = 0 result in importance = 0 for foreground service, and not passing in importance = 0 defaults to importance = 3