### PR TITLE
fix for crash from logPastTermination

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -576,7 +576,6 @@ object Radar {
         val sdkConfiguration = RadarSettings.getSdkConfiguration(this.context)
         if (sdkConfiguration.usePersistence) {
             Radar.loadReplayBufferFromSharedPreferences()
-            
         }
         if(sdkConfiguration.useLogPersistence){
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -576,6 +576,9 @@ object Radar {
         val sdkConfiguration = RadarSettings.getSdkConfiguration(this.context)
         if (sdkConfiguration.usePersistence) {
             Radar.loadReplayBufferFromSharedPreferences()
+            
+        }
+        if(sdkConfiguration.useLogPersistence){
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 this.logger.logPastTermination()
             }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -577,11 +577,6 @@ object Radar {
         if (sdkConfiguration.usePersistence) {
             Radar.loadReplayBufferFromSharedPreferences()
         }
-        if(sdkConfiguration.useLogPersistence){
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                this.logger.logPastTermination()
-            }
-        }
 
         val usage = "initialize"
         this.apiClient.getConfig(usage, false, object : RadarApiClient.RadarGetConfigApiCallback {
@@ -604,6 +599,10 @@ object Radar {
                 }
             }
         })
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            this.logger.logPastTermination()
+        }
 
         this.initialized = true
 

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -576,6 +576,9 @@ object Radar {
         val sdkConfiguration = RadarSettings.getSdkConfiguration(this.context)
         if (sdkConfiguration.usePersistence) {
             Radar.loadReplayBufferFromSharedPreferences()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                this.logger.logPastTermination()
+            }
         }
 
         val usage = "initialize"
@@ -599,10 +602,6 @@ object Radar {
                 }
             }
         })
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            this.logger.logPastTermination()
-        }
 
         this.initialized = true
 

--- a/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
@@ -1,7 +1,6 @@
 package io.radar.sdk
 
 import android.app.ActivityManager
-import java.text.SimpleDateFormat
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -11,6 +10,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import io.radar.sdk.Radar.RadarLogLevel
 import io.radar.sdk.Radar.RadarLogType
+import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
@@ -61,6 +61,12 @@ internal class RadarLogger(
     @RequiresApi(Build.VERSION_CODES.R)
     fun logPastTermination(){
         val activityManager = this.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        // only run in foreground
+        val appProcesses = activityManager.runningAppProcesses
+        val isForeground = appProcesses?.any { it.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND && it.processName == context.packageName } ?: false
+        if (!isForeground) {
+            return
+        }
         val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
         val sharedPreferences = this.context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
         val previousTimestamp = sharedPreferences.getLong("last_timestamp", 0)

--- a/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLogger.kt
@@ -60,6 +60,10 @@ internal class RadarLogger(
 
     @RequiresApi(Build.VERSION_CODES.R)
     fun logPastTermination(){
+        val level = RadarSettings.getLogLevel(this.context)
+        if (level != RadarLogLevel.DEBUG) {
+            return
+        }
         val activityManager = this.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         // only run in foreground
         val appProcesses = activityManager.runningAppProcesses
@@ -81,7 +85,7 @@ internal class RadarLogger(
         if (crashLists.isNotEmpty()) {
             for (crashInfo in crashLists) {                
                 if (crashInfo.timestamp > previousTimestamp) {
-                    Radar.sendLog(RadarLogLevel.INFO, "App terminating | with reason: ${crashInfo.getDescription()} | at ${dateFormat.format(Date(crashInfo.timestamp))} | with ${batteryLevel * 100}% battery", null, Date(crashInfo.timestamp))
+                    Radar.sendLog(RadarLogLevel.DEBUG, "App terminating | with reason: ${crashInfo.getDescription()} | at ${dateFormat.format(Date(crashInfo.timestamp))} | with ${batteryLevel * 100}% battery", null, Date(crashInfo.timestamp))
                     break
                 }
             }
@@ -101,13 +105,13 @@ internal class RadarLogger(
     fun logBackgrounding() {
         val batteryLevel = this.getBatteryLevel()
         val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-        this.i("App entering background | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
+        this.d("App entering background | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
     }
 
      fun logResigningActive() {
         val batteryLevel = this.getBatteryLevel()
         val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-        this.i("App resigning active | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
+        this.d("App resigning active | at ${dateFormat.format(Date())} | with ${batteryLevel * 100}% battery")
     }
 
 }


### PR DESCRIPTION
Changes in this PR:
- we only want to perform past termination checks for users who are RadarLogLevel.DEBUG
- we only need to check for past termination when the activity is created in the foreground.  