### PR TITLE
Headless receiver

### DIFF
--- a/sdk/local.properties
+++ b/sdk/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Fri Aug 30 16:15:15 MDT 2024
+sdk.dir=/Users/parkerstromberg/Library/Android/sdk

--- a/sdk/local.properties
+++ b/sdk/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri Aug 30 16:15:15 MDT 2024
-sdk.dir=/Users/parkerstromberg/Library/Android/sdk

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -679,12 +679,18 @@ object Radar {
             return
         }
 
-//        var paramMatch = false
-//        for (cnst in c.constructors) {
-//            if (cnst.parameterCount == 1 && cnst.parameterTypes.first()) {
-//
-//            }
-//        }
+        var constructorMatch = false
+        for (cnst in c.constructors) {
+            if (cnst.parameterTypes.size == 1 && cnst.parameterTypes.first().isAssignableFrom(Context::class.java)) {
+                constructorMatch = true
+                break;
+            }
+        }
+
+        if (!constructorMatch) {
+            this.logger.e("Provided receiver does not match required constructor signature")
+            return
+        }
 
         RadarSettings.setHeadlessReceiverName(context, c.name)
     }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -674,6 +674,11 @@ object Radar {
     }
 
     @JvmStatic
+    fun isInitialized(): Boolean {
+        return this.initialized
+    }
+
+    @JvmStatic
     fun <T : Any> setHeadlessReceiver(c: Class<T>) {
         if (!initialized) {
             return
@@ -688,11 +693,12 @@ object Radar {
         }
 
         if (!constructorMatch) {
-            this.logger.e("Provided receiver does not match required constructor signature")
+            this.logger.e("Provided receiver does not contain required constructor signature")
             return
         }
 
         RadarSettings.setHeadlessReceiverName(context, c.name)
+        this.logger.i("Registered headless receiver.")
     }
 
     @JvmStatic
@@ -3570,7 +3576,7 @@ object Radar {
                 this.receiver = headlessReceiverClass.getConstructor(Context::class.java).newInstance(context) as RadarReceiver
                 this.logger.d("Successfully attached headless receiver: $headlessReceiverName")
             } catch (e: Exception) {
-                this.logger.e("Failed to instantiate: $headlessReceiverName")
+                this.logger.e("Failed to instantiate: $headlessReceiverName", RadarLogType.SDK_EXCEPTION)
                 this.logger.e(e.toString())
             }
         }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -673,6 +673,31 @@ object Radar {
         return RadarSettings.getDescription(context)
     }
 
+    @JvmStatic
+    fun <T : Any> setHeadlessReceiver(c: Class<T>) {
+        if (!initialized) {
+            return
+        }
+
+//        var paramMatch = false
+//        for (cnst in c.constructors) {
+//            if (cnst.parameterCount == 1 && cnst.parameterTypes.first()) {
+//
+//            }
+//        }
+
+        RadarSettings.setHeadlessReceiverName(context, c.name)
+    }
+
+    @JvmStatic
+    fun clearHeadlessReceiver() {
+        if (!initialized) {
+            return
+        }
+
+        RadarSettings.setHeadlessReceiverName(context, null)
+    }
+
     /**
      * Sets an optional set of custom key-value pairs for the user.
      *
@@ -3528,6 +3553,22 @@ object Radar {
 
     internal fun setLogPersistenceFeatureFlag(enabled: Boolean) {
         this.logBuffer.setPersistentLogFeatureFlag(enabled)
+    }
+
+    internal fun attachHeadlessReceiver(context: Context) {
+        val headlessReceiverName = RadarSettings.getHeadlessReceiverName(context)
+        if (headlessReceiverName != null) {
+            try {
+                this.logger.d("Attempting to instantiate headless receiver: $headlessReceiverName")
+                val headlessReceiverClass = Class.forName(headlessReceiverName)
+                this.receiver = headlessReceiverClass.getConstructor(Context::class.java).newInstance(context) as RadarReceiver
+                this.logger.d("Successfully attached headless receiver: $headlessReceiverName")
+            } catch (e: Exception) {
+                this.logger.e("Failed to instantiate: $headlessReceiverName")
+                this.logger.e(e.toString())
+            }
+        }
+
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationReceiver.kt
@@ -122,6 +122,7 @@ class RadarLocationReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (!Radar.initialized) {
             Radar.initialize(context)
+            Radar.attachHeadlessReceiver(context)
         }
 
         Radar.logger.d("Received broadcast | action = ${intent.action}")

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -44,6 +44,7 @@ internal object RadarSettings {
     private const val KEY_OLD_SYNC_MODE = "sync_mode"
     private const val KEY_OLD_OFFLINE_MODE = "offline_mode"
     private const val KEY_USER_DEBUG = "user_debug"
+    private const val KEY_PERSISTENT_RECEIVER_NAME = "persistent_receiver_name"
 
     private fun getSharedPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
@@ -250,6 +251,16 @@ internal object RadarSettings {
         val optionsJson = getSharedPreferences(context).getString(KEY_NOTIFICATION_OPTIONS, null) ?: return null
         val optionsObj = JSONObject(optionsJson)
         return RadarNotificationOptions.fromJson(optionsObj)
+    }
+
+    internal fun getHeadlessReceiverName(context: Context): String? {
+        return getSharedPreferences(context).getString(KEY_PERSISTENT_RECEIVER_NAME, null)
+    }
+
+    internal fun setHeadlessReceiverName(context: Context, name: String?) {
+        getSharedPreferences(context).edit {
+            putString(KEY_PERSISTENT_RECEIVER_NAME, name)
+        }
     }
 
     internal fun getForegroundService(context: Context): RadarTrackingOptions.RadarTrackingOptionsForegroundService {

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -265,7 +265,8 @@ internal object RadarState {
         }
     }
 
-    internal fun getLastMotionActivity(context: Context): JSONObject? {
+    @JvmStatic
+    fun getLastMotionActivity(context: Context): JSONObject? {
         val jsonString = getSharedPreferences(context).getString(KEY_LAST_MOTION_ACTIVITY, null)
         return stringToJsonObject(jsonString)
     }


### PR DESCRIPTION
## Problem

Currently when a location update intent is received and Radar is not initialized, Radar will initialize with no user provided receiver. This is an issue if the user is interested in handling location updates that occur post-termination.

## Solution

The solution implemented in this PR allows SDK user's to register a `RadarReceiver` as a "headless receiver". The headless receiver must implement a constructor taking in a single parameter of type `Context` and depend only on that to bootstrap. After Radar initializes post-termination the SDK will attempt to attach any provided headless receiver, giving the client an opportunity to receive events.