### PR TITLE
enable logging on live projects, default log level to NONE on live

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.18.0'
+    radarVersion = '3.18.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3517,9 +3517,7 @@ object Radar {
 
     internal fun sendLog(level: RadarLogLevel, message: String, type: RadarLogType?, createdAt: Date = Date()) {
         receiver?.onLog(context, message)
-        if (isTestKey()) {
-            logBuffer.write(level, type, message, createdAt)
-        }
+        logBuffer.write(level, type, message, createdAt)
     }
 
     internal fun sendToken(token: RadarVerifiedLocationToken) {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -329,7 +329,8 @@ internal object RadarSettings {
     }
 
     internal fun getLogLevel(context: Context): Radar.RadarLogLevel {
-        val logLevelInt = getSharedPreferences(context).getInt(KEY_LOG_LEVEL, Radar.RadarLogLevel.INFO.value)
+        val defaultLogLevel = if (Radar.isTestKey()) Radar.RadarLogLevel.INFO else Radar.RadarLogLevel.NONE
+        val logLevelInt = getSharedPreferences(context).getInt(KEY_LOG_LEVEL, defaultLogLevel.value)
         val userDebug = getUserDebug(context)
         return if (userDebug) Radar.RadarLogLevel.DEBUG else Radar.RadarLogLevel.fromInt(logLevelInt)
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -329,8 +329,7 @@ internal object RadarSettings {
     }
 
     internal fun getLogLevel(context: Context): Radar.RadarLogLevel {
-        val defaultLogLevel = if (Radar.isTestKey()) Radar.RadarLogLevel.INFO else Radar.RadarLogLevel.NONE
-        val logLevelInt = getSharedPreferences(context).getInt(KEY_LOG_LEVEL, defaultLogLevel.value)
+        val logLevelInt = getSharedPreferences(context).getInt(KEY_LOG_LEVEL, Radar.RadarLogLevel.INFO.value)
         val userDebug = getUserDebug(context)
         return if (userDebug) Radar.RadarLogLevel.DEBUG else Radar.RadarLogLevel.fromInt(logLevelInt)
     }


### PR DESCRIPTION
https://linear.app/radarlabs/issue/FENCE-2088/default-log-level-to-none-for-production-projects

clean up the code path for flushing log buffer, we want to flush whenever we do have logs. the default log level for live is NONE and for test is INFO, which are set from the server via remote SDK config.