### PR TITLE
[Experiment/WIP] Android notification improvements. 

### DIFF
--- a/example/src/main/java/io/radar/example/MyRadarReceiver.kt
+++ b/example/src/main/java/io/radar/example/MyRadarReceiver.kt
@@ -2,7 +2,9 @@ package io.radar.example
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.location.Location
 import android.os.Build
 import androidx.core.app.NotificationCompat
@@ -12,7 +14,7 @@ import io.radar.sdk.RadarReceiver
 import io.radar.sdk.model.RadarEvent
 import io.radar.sdk.model.RadarUser
 
-class MyRadarReceiver : RadarReceiver() {
+class MyRadarReceiver() : RadarReceiver() {
 
     companion object {
 
@@ -33,11 +35,18 @@ class MyRadarReceiver : RadarReceiver() {
                 notificationManager.createNotificationChannel(channel)
             }
 
+            val intent = Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
             val builder = NotificationCompat.Builder(context, channelId)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setStyle(NotificationCompat.BigTextStyle().bigText(body))
                 .setContentText(body)
                 .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true)
 
             with(NotificationManagerCompat.from(context)) {
                 notify(identifier % 20, builder.build())
@@ -47,7 +56,10 @@ class MyRadarReceiver : RadarReceiver() {
     }
 
     override fun onEventsReceived(context: Context, events: Array<RadarEvent>, user: RadarUser?) {
-        events.forEach { event -> notify(context, Utils.stringForRadarEvent(event)) }
+        events.forEach { event -> {
+        //notify(context, Utils.stringForRadarEvent(event))
+        }
+        }
     }
 
     override fun onLocationUpdated(context: Context, location: Location, user: RadarUser) {
@@ -61,11 +73,11 @@ class MyRadarReceiver : RadarReceiver() {
     }
 
     override fun onError(context: Context, status: Radar.RadarStatus) {
-        notify(context, Utils.stringForRadarStatus(status))
+        //notify(context, Utils.stringForRadarStatus(status))
     }
 
     override fun onLog(context: Context, message: String) {
-        notify(context, message)
+        //notify(context, message)
     }
 
 }

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -21,6 +21,14 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:name=".RadarNotificationReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter android:priority="999">
+                <action android:name="io.radar.sdk.NotificationReceiver.CONVERSION" />
+            </intent-filter>
+        </receiver>
         <service android:name=".RadarJobScheduler"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true" />

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -459,7 +459,7 @@ object Radar {
     internal var initialized = false
     internal var isFlushingReplays = false
     private lateinit var context: Context
-    private var activity: Activity? = null
+    internal var activity: Activity? = null
     internal lateinit var handler: Handler
     private var receiver: RadarReceiver? = null
     private var verifiedReceiver: RadarVerifiedReceiver? = null
@@ -3166,12 +3166,32 @@ object Radar {
         if (!RadarSettings.getSdkConfiguration(context).useOpenedAppConversion) {
             return
         }
-        // if opened_app has been logged in the last 1000 milliseconds, don't log it again
+        // if opened_app_test has been logged in the last 1000 milliseconds, don't log it again
         val timestamp = System.currentTimeMillis()
         val lastAppOpenTime = RadarSettings.getLastAppOpenTimeMillis(context)
         if (timestamp - lastAppOpenTime > 1000) {
             RadarSettings.updateLastAppOpenTimeMillis(context)
-            sendLogConversionRequest("opened_app", callback = object : RadarLogConversionCallback {
+            sendLogConversionRequest("opened_app_test", callback = object : RadarLogConversionCallback {
+                override fun onComplete(status: RadarStatus, event: RadarEvent?) {
+                    logger.i("Conversion name = ${event?.conversionName}: status = $status; event = $event")
+                }
+            })
+        }
+    }
+
+    internal fun logOpenedAppConversionFromNotification() {
+        if (!RadarSettings.getSdkConfiguration(context).useOpenedAppConversion) {
+            return
+        }
+        // if opened_app_test has been logged in the last 1000 milliseconds, don't log it again
+        val timestamp = System.currentTimeMillis()
+        val lastAppOpenTime = RadarSettings.getLastAppOpenTimeMillis(context)
+        if (timestamp - lastAppOpenTime > 1000) {
+            RadarSettings.updateLastAppOpenTimeMillis(context)
+            val metaData = JSONObject().apply {
+                put("conversionSource", "radar_notification")
+            }
+            sendLogConversionRequest("opened_app_test", metaData, callback = object : RadarLogConversionCallback {
                 override fun onComplete(status: RadarStatus, event: RadarEvent?) {
                     logger.i("Conversion name = ${event?.conversionName}: status = $status; event = $event")
                 }

--- a/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarActivityLifecycleCallbacks.kt
@@ -139,5 +139,11 @@ internal class RadarActivityLifecycleCallbacks(
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         Log.w(TAG, "ON CREATE ${count}")
         updatePermissionsDenied(activity)
+        val res = activity.intent.extras?.getBoolean("radarNotification")
+        Log.i("testing",activity.intent.extras.toString())
+        if (res == true) {
+            Log.i("testing","called from notification")
+            Radar.logOpenedAppConversionFromNotification()
+        }
     }
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
@@ -5,27 +5,36 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Context.NOTIFICATION_SERVICE
+import android.graphics.Color
 import android.os.Build
-import android.app.PendingIntent
-import android.content.Intent
 import androidx.core.app.NotificationCompat
 import io.radar.sdk.model.RadarEvent
-import android.graphics.Color
 
 class RadarNotificationHelper {
 
     internal companion object {
         private const val CHANNEL_NAME = "Location"
         private const val NOTIFICATION_ID = 20160525 // Radar's birthday!
+        val SUMMARY_NOTIFICATION_GROUP = "io.radar.sdk.event_notification"
+        val SUMMARY_ID = 0
 
-        @SuppressLint("DiscouragedApi")
+        @SuppressLint("DiscouragedApi", "LaunchActivityFromNotification")
         internal fun showNotifications(context: Context, events: Array<RadarEvent>) {
             if (Build.VERSION.SDK_INT < 26) {
                 return
             }
 
+            var notificationsCount = 0
+            val notificationManager =
+                context.getSystemService(NOTIFICATION_SERVICE) as? NotificationManager
+
+            val importance = NotificationManager.IMPORTANCE_HIGH
+            val channel = NotificationChannel(CHANNEL_NAME, CHANNEL_NAME, importance)
+            channel.enableVibration(true)
+            notificationManager?.createNotificationChannel(channel)
+
             for (event in events) {
-                var notificationText: String? = null
+                var notificationText: String? = "dummy var"
 
                 if (event.type == RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE) {
                     notificationText = event.geofence?.metadata?.optString("radar:entryNotificationText")
@@ -44,13 +53,7 @@ class RadarNotificationHelper {
                 if (notificationText != null && notificationText.isNotEmpty()) {
                     val id = event._id
 
-                    val notificationManager =
-                        context.getSystemService(NOTIFICATION_SERVICE) as? NotificationManager
 
-                    val importance = NotificationManager.IMPORTANCE_HIGH
-                    val channel = NotificationChannel(CHANNEL_NAME, CHANNEL_NAME, importance)
-                    channel.enableVibration(true)
-                    notificationManager?.createNotificationChannel(channel)
 
                     val notificationOptions = RadarSettings.getNotificationOptions(context);
 
@@ -68,11 +71,44 @@ class RadarNotificationHelper {
                     if (iconColor.isNotEmpty()) {
                         builder.setColor(Color.parseColor(iconColor))
                     }
+
+                    builder.setContentIntent(RadarNotificationReceiver.getNotificationConversionPendingIntent(context))
+                    builder.setAutoCancel(true)
+                    builder.setGroup(SUMMARY_NOTIFICATION_GROUP)
                     
                     notificationManager?.notify(id, NOTIFICATION_ID, builder.build())
+                    notificationsCount++
                 }
             }
+            if (notificationsCount > 0) {
+                val notificationOptions = RadarSettings.getNotificationOptions(context);
+
+                    val iconString = notificationOptions?.getEventIcon()?: context.applicationContext.applicationInfo.icon.toString()
+                    val smallIcon = context.applicationContext.resources.getIdentifier(iconString, "drawable", context.applicationContext.packageName)
+                    val notificationText = "You have ${notificationsCount} location sensitive notifications"
+                    val builder = NotificationCompat.Builder(context, CHANNEL_NAME)
+                        .setSmallIcon(smallIcon)
+                        .setAutoCancel(true)
+                        .setContentText(notificationText)
+                        .setStyle(NotificationCompat.BigTextStyle().bigText(notificationText))
+                        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+                    val iconColor = notificationOptions?.getEventColor()?: ""
+                    if (iconColor.isNotEmpty()) {
+                        builder.setColor(Color.parseColor(iconColor))
+                    }
+
+                    builder.setContentIntent(RadarNotificationReceiver.getNotificationConversionPendingIntent(context))
+                    builder.setAutoCancel(true)
+                    builder.setGroup(SUMMARY_NOTIFICATION_GROUP)
+                    builder.setGroupSummary(true)
+                    
+                    notificationManager?.notify(SUMMARY_ID, builder.build())
+            }
+
+
         }
+
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationOptions.kt
@@ -1,7 +1,6 @@
 package io.radar.sdk
 
 import org.json.JSONObject
-import java.util.Date
 
 /**
  * An options class used to configure local notifications.
@@ -38,6 +37,8 @@ data class RadarNotificationOptions(
      * Determines the name of the asset to be used for event notifications. Optional, defaults to iconString.
      */
     val eventIconColor: String? = null,
+
+
 ) {
 
     companion object {

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationReceiver.kt
@@ -1,0 +1,39 @@
+package io.radar.sdk
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class RadarNotificationReceiver : BroadcastReceiver() {
+
+    internal companion object{
+        internal const val ACTION_NOTIFICATION_CONVERSION = "io.radar.sdk.NotificationReceiver.CONVERSION"
+        private const val REQUEST_CODE_NOTIFICATION_CONVERSION = 201605255
+        internal fun getNotificationConversionPendingIntent(context: Context): PendingIntent? {
+            val activityIntent = Intent(context, Radar.activity!!::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            activityIntent.putExtra("radarNotification", true)
+            val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 0, activityIntent,
+                PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE)
+            return pendingIntent
+        }
+        private fun baseIntent(context: Context): Intent = Intent(context, RadarNotificationReceiver::class.java)
+    }
+    override fun onReceive(context: Context, intent: Intent) {
+        if (!Radar.initialized) {
+            Radar.initialize(context)
+        }
+        if (intent.action == ACTION_NOTIFICATION_CONVERSION) {
+            Radar.logger.d("Received broadcast  inside radarnoticiationreciever | action = ${intent.action}")
+
+            val mainIntent = Intent(context, Radar.activity!!::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            context.startActivity(mainIntent)
+            Log.i("testing", "running chunk of code")
+        }
+    }
+}


### PR DESCRIPTION
Spike to improve android notifications in SDK
* first pass implementation to log app opened from radar notifications
    * we create a pending intent that will open the main activity of the app
    * we attach an extra flag that will allow the activity lifecycle receiver to detect app opens from notifications.
* adds content intent to define the on tap behavior
* draft implementation of summary notification

This exploration uncovered some area for future work and product improvements.
* better define the behavior of content taps
* better implementation of the summary notifications
* more robust logging of app opens

These product definitions should be made in conjunction with the upcoming notification builder work.

links to projects with similar implementations
- https://github.com/wix/react-native-notifications
- https://github.com/OneSignal/OneSignal-Android-SDK/tree/main
