### PR TITLE
only clear geofences when we have a new array of nearby geofences

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -354,8 +354,10 @@ internal class RadarLocationManager(
     }
 
     private fun replaceSyncedGeofences(radarGeofences: Array<RadarGeofence>?) {
-        this.removeSyncedGeofences() { success ->
-            this.addSyncedGeofences(radarGeofences)
+        if (radarGeofences != null) {
+            this.removeSyncedGeofences() { success ->
+                this.addSyncedGeofences(radarGeofences)
+            }
         }
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -358,6 +358,8 @@ internal class RadarLocationManager(
             this.removeSyncedGeofences() { success ->
                 this.addSyncedGeofences(radarGeofences)
             }
+        } else {
+            logger.d("Skipping replace synced geofences")
         }
     }
 


### PR DESCRIPTION
Relevant if what's being sent up is a /track/replay, where we early `200`.