### PR TITLE
Allow for createTrip without starting tracking immediately

### DIFF
--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -21,6 +21,7 @@ import java.util.EnumSet
 import androidx.core.content.edit
 import io.radar.sdk.model.RadarAddress
 import io.radar.sdk.model.RadarCoordinate
+import java.util.*
 
 class MainActivity : AppCompatActivity() {
 
@@ -32,7 +33,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         val receiver = MyRadarReceiver()
-        Radar.initialize(this, "prj_test_pk_0000000000000000000000000000000000000000", receiver, Radar.RadarLocationServicesProvider.GOOGLE, true)
+        Radar.initialize(this, "prj_test_pk_000000000000000000000000000000000000", receiver, Radar.RadarLocationServicesProvider.GOOGLE, true)
         Radar.sdkVersion().let { Log.i("version", it) }
 
         val verifiedReceiver = object : RadarVerifiedReceiver() {
@@ -380,6 +381,64 @@ class MainActivity : AppCompatActivity() {
                     "Distance: status = $status; routes.car.distance.value = ${routes?.car?.distance?.value}; routes.car.distance.text = ${routes?.car?.distance?.text}; routes.car.duration.value = ${routes?.car?.duration?.value}; routes.car.duration.text = ${routes?.car?.duration?.text}"
                 )
             }
+        }
+
+       createButton("startTrip") {
+            val tripOptions = RadarTripOptions(
+                "400",
+                null,
+                "store",
+                "123",
+                Radar.RadarRouteMode.CAR,
+                approachingThreshold = 9
+            )
+            Radar.startTrip(tripOptions)
+        }
+
+        createButton("startTrip with start tracking false") {
+            val tripOptions = RadarTripOptions(
+                "501",
+                null,
+                "store",
+                "123",
+                Radar.RadarRouteMode.CAR,
+                approachingThreshold = 9,
+                startTracking = false
+            )
+            Radar.startTrip(tripOptions)
+        }
+
+        createButton("startTrip with tracking options") {
+            val tripOptions = RadarTripOptions(
+                "502",
+                null,
+                "store",
+                "123",
+                Radar.RadarRouteMode.CAR,
+                approachingThreshold = 9
+            )
+            val onTripTrackingOptions = RadarTrackingOptions.CONTINUOUS
+            Radar.startTrip(tripOptions, onTripTrackingOptions)
+        }
+
+        createButton("startTrip with tracking options and startTrackingAfter") {
+            val tripOptions = RadarTripOptions(
+                "507",
+                null,
+                "store",
+                "123",
+                Radar.RadarRouteMode.CAR,
+                approachingThreshold = 9,
+                startTracking = false
+            )
+            val onTripTrackingOptions = RadarTrackingOptions.CONTINUOUS
+            // startTrackingAfter 3 minutes from now
+            onTripTrackingOptions.startTrackingAfter = Date(System.currentTimeMillis() + (3 * 60 * 1000))
+            Radar.startTrip(tripOptions, onTripTrackingOptions)
+        }
+
+        createButton("completeTrip") {
+            Radar.completeTrip()
         }
 
         createButton("mockTracking") {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.18.5'
+    radarVersion = '3.18.6'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1537,7 +1537,7 @@ object Radar {
                         RadarSettings.removePreviousTrackingOptions(context)
                     }
 
-                    if (trackingOptions != null && trackingOptions.startTrackingAfter != null) {
+                    if (trackingOptions != null && trackingOptions.startTrackingAfter == null) {
                         Radar.startTracking(trackingOptions)
                     } else if (trackingOptions != null) {
                         RadarSettings.setTrackingOptions(context, trackingOptions)

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1537,9 +1537,11 @@ object Radar {
                         RadarSettings.removePreviousTrackingOptions(context)
                     }
 
-                    if (trackingOptions != null) {
+                    if (trackingOptions != null && trackingOptions.startTrackingAfter != null) {
                         Radar.startTracking(trackingOptions)
-                    } else if (!isTracking) {
+                    } else if (trackingOptions != null) {
+                        RadarSettings.setTrackingOptions(context, trackingOptions)
+                    } else if (!isTracking && options.startTracking) {
                         Radar.startTracking(RadarSettings.getRemoteTrackingOptions(context) ?: RadarSettings.getTrackingOptions(context))
                     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -118,6 +118,12 @@ internal class RadarLocationManager(
     fun stopTracking() {
         this.started = false
         RadarSettings.setTracking(context, false)
+        // null out startTrackingAfter and stopTrackingAfter in the local tracking options
+        // so that tracking isn't restarted with a trackOnce call
+        val trackingOptions = RadarSettings.getTrackingOptions(context)
+        trackingOptions.startTrackingAfter = null
+        trackingOptions.stopTrackingAfter = null
+        RadarSettings.setTrackingOptions(context, trackingOptions)
         this.updateTracking()
         val settings = RadarSettings.getSdkConfiguration(context)
         if (settings.extendFlushReplays) {

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -175,16 +175,17 @@ internal class RadarLocationManager(
     internal fun updateTracking(location: Location? = null) {
         var tracking = RadarSettings.getTracking(context)
         val options = Radar.getTrackingOptions()
+        val localOptions = RadarSettings.getTrackingOptions(context)
 
         logger.d("Updating tracking | options = $options; location = $location")
 
         val now = Date()
-        if (!tracking && options.startTrackingAfter != null && options.startTrackingAfter!!.before(now)) {
+        if (!tracking && localOptions.startTrackingAfter != null && localOptions.startTrackingAfter!!.before(now)) {
             logger.d("Starting time-based tracking | startTrackingAfter = ${options.startTrackingAfter}")
 
             tracking = true
             RadarSettings.setTracking(context, true)
-        } else if (tracking && options.stopTrackingAfter != null && options.stopTrackingAfter!!.before(now)) {
+        } else if (tracking && localOptions.stopTrackingAfter != null && localOptions.stopTrackingAfter!!.before(now)) {
             logger.d("Stopping time-based tracking | startTrackingAfter = ${options.startTrackingAfter}")
 
             tracking = false

--- a/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
@@ -39,7 +39,7 @@ data class RadarTripOptions(
      */
     var scheduledArrivalAt: Date? = null,
 
-    var approachingThreshold: Int = 0
+    var approachingThreshold: Int = 0,
 
     var startTracking: Boolean = true
 ) {

--- a/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
@@ -40,6 +40,8 @@ data class RadarTripOptions(
     var scheduledArrivalAt: Date? = null,
 
     var approachingThreshold: Int = 0
+
+    var startTracking: Boolean = true
 ) {
 
     companion object {
@@ -51,6 +53,7 @@ data class RadarTripOptions(
         internal const val KEY_MODE = "mode"
         internal const val KEY_SCHEDULED_ARRIVAL_AT = "scheduledArrivalAt"
         internal const val KEY_APPROACHING_THRESHOLD = "approachingThreshold"
+        internal const val KEY_START_TRACKING = "startTracking"
 
         @JvmStatic
         fun fromJson(obj: JSONObject): RadarTripOptions {
@@ -77,6 +80,7 @@ data class RadarTripOptions(
                     }
                 } else null,
                 approachingThreshold = obj.optInt(KEY_APPROACHING_THRESHOLD)
+                startTracking = obj.optBoolean(KEY_START_TRACKING, true)
             )
         }
 
@@ -95,6 +99,7 @@ data class RadarTripOptions(
         if (approachingThreshold > 0) {
             obj.put(KEY_APPROACHING_THRESHOLD, approachingThreshold)
         }
+        obj.put("startTracking", startTracking)
         return obj
     }
 
@@ -115,7 +120,8 @@ data class RadarTripOptions(
                 this.destinationGeofenceExternalId == other.destinationGeofenceExternalId &&
                 this.mode == other.mode &&
                 this.scheduledArrivalAt?.time == other.scheduledArrivalAt?.time &&
-                this.approachingThreshold == other.approachingThreshold
+                this.approachingThreshold == other.approachingThreshold &&
+                this.startTracking == other.startTracking
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTripOptions.kt
@@ -79,7 +79,7 @@ data class RadarTripOptions(
                         RadarUtils.isoStringToDate(obj.optString(KEY_SCHEDULED_ARRIVAL_AT))
                     }
                 } else null,
-                approachingThreshold = obj.optInt(KEY_APPROACHING_THRESHOLD)
+                approachingThreshold = obj.optInt(KEY_APPROACHING_THRESHOLD),
                 startTracking = obj.optBoolean(KEY_START_TRACKING, true)
             )
         }


### PR DESCRIPTION
Allows you to pass `tripOptions.startTracking = NO` to not automatically start tracking. The default remains that tracking starts automatically.

Starting tracking also doesn't happen automatically if `trackingOptions.startTrackingAfter` is non-nil.

We explicitly check the local tracking options for `startTrackingAfter` and `stopTrackingAfter` so that RTO can be used in conjunction with these local tracking options.

Finally, we make sure that if you call `Radar.stopTracking()` after having started tracking with a `trackingOption.startTrackingAfter`, that tracking remains off until `Radar.startTracking()` is called again.