### PR TITLE
Replay time ordering

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.18.9-beta.1'
+    radarVersion = '3.18.9'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.18.5'
+    radarVersion = '3.18.6-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -2,7 +2,6 @@ package io.radar.sdk
 
 import android.content.Context
 import android.location.Location
-import android.net.Uri
 import android.os.Build
 import android.os.SystemClock
 import io.radar.sdk.Radar.RadarAddressVerificationStatus
@@ -305,13 +304,16 @@ internal class RadarApiClient(
                     params.putOpt("courseAccuracy", location.bearingAccuracyDegrees)
                 }
             }
-            val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
-            val locationMs = location.elapsedRealtimeNanos / 1000000
-            val updatedAtMsDiff = (nowMs - locationMs)
-            if ((!foreground || !verified) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
+                val locationMs = location.elapsedRealtimeNanos / 1000000
+                val updatedAtMsDiff = (nowMs - locationMs)
+                if ((!foreground || !verified)) {
+                    params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
+
+                }
+                params.putOpt("locationMs", locationMs)
             }
-            params.putOpt("locationMs", locationMs)
             params.putOpt("foreground", foreground)
             params.putOpt("stopped", stopped)
             params.putOpt("replayed", replayed)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -308,10 +308,7 @@ internal class RadarApiClient(
                 val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
                 val locationMs = location.elapsedRealtimeNanos / 1000000
                 val updatedAtMsDiff = (nowMs - locationMs)
-                if ((!foreground || !verified)) {
-                    params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
-
-                }
+                params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
                 params.putOpt("locationMs", locationMs)
             }
             params.putOpt("foreground", foreground)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -305,10 +305,13 @@ internal class RadarApiClient(
                     params.putOpt("courseAccuracy", location.bearingAccuracyDegrees)
                 }
             }
-            if (!foreground && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                val updatedAtMsDiff = (SystemClock.elapsedRealtimeNanos() - location.elapsedRealtimeNanos) / 1000000
+            val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
+            val locationMs = location.elapsedRealtimeNanos / 1000000
+            val updatedAtMsDiff = (nowMs - locationMs)
+            if ((!foreground || !verified) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
             }
+            params.putOpt("locationMs", locationMs)
             params.putOpt("foreground", foreground)
             params.putOpt("stopped", stopped)
             params.putOpt("replayed", replayed)
@@ -396,8 +399,6 @@ internal class RadarApiClient(
 
         val hasReplays = Radar.hasReplays()
         var requestParams = params
-        val nowMS = System.currentTimeMillis()
-
         // before we track, check if replays need to sync
         val replaying = options.replay == RadarTrackingOptions.RadarTrackingOptionsReplay.ALL && hasReplays && !verified
         if (replaying) {
@@ -418,8 +419,6 @@ internal class RadarApiClient(
                 if (status != RadarStatus.SUCCESS || res == null) {
                     if (options.replay == RadarTrackingOptions.RadarTrackingOptionsReplay.ALL) {
                         params.putOpt("replayed", true)
-                        params.putOpt("updatedAtMs", nowMS)
-                        params.remove("updatedAtMsDiff")
                         Radar.addReplay(params)
                     } else if (options.replay == RadarTrackingOptions.RadarTrackingOptionsReplay.STOPS && stopped && !(source == RadarLocationSource.FOREGROUND_LOCATION || source == RadarLocationSource.BACKGROUND_LOCATION)) {
                         RadarState.setLastFailedStoppedLocation(context, location)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -308,7 +308,9 @@ internal class RadarApiClient(
                 val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
                 val locationMs = location.elapsedRealtimeNanos / 1000000
                 val updatedAtMsDiff = (nowMs - locationMs)
-                params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
+                if (RadarSettings.getSdkConfiguration(context).useForegroundLocationUpdatedAtMsDiff || !foreground) {
+                    params.putOpt("updatedAtMsDiff", updatedAtMsDiff)
+                }
                 params.putOpt("locationMs", locationMs)
             }
             params.putOpt("foreground", foreground)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
@@ -82,12 +82,14 @@ internal open class RadarApiHelper(
                     val replays = params.optJSONArray("replays")
 
                     if (updatedAtMsDiff != -1L || replays != null) {
+                        val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
+
                         val locationMs = params.optLong("locationMs", -1L)
-                        val nowMs = SystemClock.elapsedRealtime()
                         if (locationMs != -1L){
                             val updatedAtMsDiff = nowMs - locationMs
                             params.put("updatedAtMsDiff", updatedAtMsDiff)
                         }
+
                         if (replays != null) {
                             val updatedReplays = ArrayList<JSONObject>(replays.length())
                             for (i in 0 until replays.length()) {
@@ -101,6 +103,7 @@ internal open class RadarApiHelper(
                                     updatedReplays.add(it)
                                 }
                             }
+                            params.put("replays", updatedReplays)
                         }
                     }
                     urlConnection.doOutput = true

--- a/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
@@ -86,6 +86,7 @@ internal open class RadarApiHelper(
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && (prevUpdatedAtMsDiff != -1L || replays != null)) {
                         val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
                         val locationMs = params.optLong("locationMs", -1L)
+
                         if (prevUpdatedAtMsDiff != -1L && locationMs != -1L){
                             val updatedAtMsDiff = nowMs - locationMs
                             params.put("updatedAtMsDiff", updatedAtMsDiff)
@@ -107,8 +108,8 @@ internal open class RadarApiHelper(
                             params.put("replays", JSONArray(updatedReplays))
                         }
                     }
-                    urlConnection.doOutput = true
 
+                    urlConnection.doOutput = true
                     val outputStreamWriter = OutputStreamWriter(urlConnection.outputStream)
                     outputStreamWriter.write(params.toString())
                     outputStreamWriter.close()

--- a/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
@@ -7,6 +7,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import io.radar.sdk.Radar.RadarLogType
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
@@ -92,7 +93,7 @@ internal open class RadarApiHelper(
                         }
 
                         if (replays != null) {
-                            val updatedReplays = ArrayList<JSONObject>(replays.length())
+                            val updatedReplays = mutableListOf<JSONObject>()
                             for (i in 0 until replays.length()) {
                                 val replay = replays.optJSONObject(i)
                                 replay?.let {
@@ -104,7 +105,7 @@ internal open class RadarApiHelper(
                                     updatedReplays.add(it)
                                 }
                             }
-                            params.put("replays", updatedReplays)
+                            params.put("replays", JSONArray(updatedReplays))
                         }
                     }
                     urlConnection.doOutput = true

--- a/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
@@ -80,14 +80,13 @@ internal open class RadarApiHelper(
                 }
 
                 if (params != null) {
-                    val updatedAtMsDiff = params.optLong("updatedAtMsDiff", -1L)
+                    val prevUpdatedAtMsDiff = params.optLong("updatedAtMsDiff", -1L)
                     val replays = params.optJSONArray("replays")
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && ( updatedAtMsDiff != -1L || replays != null)) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && (prevUpdatedAtMsDiff != -1L || replays != null)) {
                         val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
-
                         val locationMs = params.optLong("locationMs", -1L)
-                        if (locationMs != -1L){
+                        if (prevUpdatedAtMsDiff != 1L && locationMs != -1L){
                             val updatedAtMsDiff = nowMs - locationMs
                             params.put("updatedAtMsDiff", updatedAtMsDiff)
                         }

--- a/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
@@ -86,7 +86,7 @@ internal open class RadarApiHelper(
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && (prevUpdatedAtMsDiff != -1L || replays != null)) {
                         val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
                         val locationMs = params.optLong("locationMs", -1L)
-                        if (prevUpdatedAtMsDiff != 1L && locationMs != -1L){
+                        if (prevUpdatedAtMsDiff != -1L && locationMs != -1L){
                             val updatedAtMsDiff = nowMs - locationMs
                             params.put("updatedAtMsDiff", updatedAtMsDiff)
                         }

--- a/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
@@ -2,6 +2,7 @@ package io.radar.sdk
 
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
@@ -81,7 +82,7 @@ internal open class RadarApiHelper(
                     val updatedAtMsDiff = params.optLong("updatedAtMsDiff", -1L)
                     val replays = params.optJSONArray("replays")
 
-                    if (updatedAtMsDiff != -1L || replays != null) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && ( updatedAtMsDiff != -1L || replays != null)) {
                         val nowMs = SystemClock.elapsedRealtimeNanos() / 1000000
 
                         val locationMs = params.optLong("locationMs", -1L)

--- a/sdk/src/main/java/io/radar/sdk/model/RadarSdkConfiguration.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarSdkConfiguration.kt
@@ -21,6 +21,7 @@ internal data class RadarSdkConfiguration(
     val trackOnceOnAppOpen: Boolean,
     val useLocationMetadata: Boolean,
     val useOpenedAppConversion: Boolean = false,
+    val useForegroundLocationUpdatedAtMsDiff: Boolean = false,
 ) {
     companion object {
         private const val MAX_CONCURRENT_JOBS = "maxConcurrentJobs"
@@ -35,6 +36,7 @@ internal data class RadarSdkConfiguration(
         private const val TRACK_ONCE_ON_APP_OPEN = "trackOnceOnAppOpen"
         private const val USE_LOCATION_METADATA = "useLocationMetadata"
         private const val USE_OPENED_APP_CONVERSION = "useOpenedAppConversion"
+        private const val USE_FOREGROUND_LOCATION_UPDATED_AT_MS_DIFF = "useForegroundLocationUpdatedAtMsDiff"
 
 
         fun fromJson(json: JSONObject?): RadarSdkConfiguration {
@@ -53,6 +55,7 @@ internal data class RadarSdkConfiguration(
                 config.optBoolean(TRACK_ONCE_ON_APP_OPEN, false),
                 config.optBoolean(USE_LOCATION_METADATA, false),
                 config.optBoolean(USE_OPENED_APP_CONVERSION, true),
+                config.optBoolean(USE_FOREGROUND_LOCATION_UPDATED_AT_MS_DIFF, false),
             )
         }
 
@@ -82,6 +85,7 @@ internal data class RadarSdkConfiguration(
             putOpt(TRACK_ONCE_ON_APP_OPEN, trackOnceOnAppOpen)
             putOpt(USE_LOCATION_METADATA, useLocationMetadata)
             putOpt(USE_OPENED_APP_CONVERSION, useOpenedAppConversion)
+            putOpt(USE_FOREGROUND_LOCATION_UPDATED_AT_MS_DIFF, useForegroundLocationUpdatedAtMsDiff)
         }
     }
 }

--- a/sdk/src/test/java/io/radar/sdk/model/RadarSdkConfigurationTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/model/RadarSdkConfigurationTest.kt
@@ -29,6 +29,7 @@ class RadarSdkConfigurationTest {
     private var trackOnceOnAppOpen = false
     private var useLocationMetadata = false
     private var useOpenedAppConversion = false
+    private var useForegroundLocationUpdatedAtMsDiff = false
 
     @Before
     fun setUp() {
@@ -46,7 +47,8 @@ class RadarSdkConfigurationTest {
             "startTrackingOnInitialize":$startTrackingOnInitialize,
             "trackOnceOnAppOpen":$trackOnceOnAppOpen,
             "useLocationMetadata":$useLocationMetadata,
-            "useOpenedAppConversion":$useOpenedAppConversion
+            "useOpenedAppConversion":$useOpenedAppConversion,
+            "useForegroundLocationUpdatedAtMsDiff":$useForegroundLocationUpdatedAtMsDiff
         }""".trimIndent()
     }
 
@@ -65,7 +67,8 @@ class RadarSdkConfigurationTest {
                 startTrackingOnInitialize,
                 trackOnceOnAppOpen,
                 useLocationMetadata,
-                useOpenedAppConversion
+                useOpenedAppConversion,
+                useForegroundLocationUpdatedAtMsDiff
             ).toJson().toString()
         )
     }
@@ -84,6 +87,7 @@ class RadarSdkConfigurationTest {
         assertEquals(trackOnceOnAppOpen, settings.trackOnceOnAppOpen)
         assertEquals(useLocationMetadata, settings.useLocationMetadata)
         assertEquals(useOpenedAppConversion, settings.useOpenedAppConversion)
+        assertEquals(useForegroundLocationUpdatedAtMsDiff, settings.useForegroundLocationUpdatedAtMsDiff)
     }
 
     @Test
@@ -100,6 +104,7 @@ class RadarSdkConfigurationTest {
         assertFalse(settings.trackOnceOnAppOpen)
         assertFalse(settings.useLocationMetadata)
         assertTrue(settings.useOpenedAppConversion)
+        assertFalse(settings.useForegroundLocationUpdatedAtMsDiff)
     }
 
     private fun String.removeWhitespace(): String = replace("\\s".toRegex(), "")


### PR DESCRIPTION
We do 2 things here:
- for all tracks we include the `updatedAtMsDiff`, which will be used to determine the `location.updatedAt`
- we modify `updatedAtMsDiff` in `RadarAPIHelper` to update `updatedAtMsDiff` at request time, as `updatedAtMsDiff` is meant to represent the difference between the client request time and the timestamp of the location processed by the SDK. This is an important fix to locations being replayed as previously their `updatedAtMsDiff` was determined by their original (failed) request time — not actually the time at successful request.