### PR TITLE
add RadarVerifyServer

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation "com.google.android.play:integrity:1.2.0"
+    implementation 'org.nanohttpd:nanohttpd:2.3.1'
 }

--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -123,14 +123,6 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        createButton("startVerifyServer") {
-            Radar.startVerifyServer()
-        }
-
-        createButton("stopTrackingVerified") {
-            Radar.stopVerifyServer()
-        }
-
         createButton("trackVerified") {
             Radar.trackVerified(false) { status, token ->
                 Log.v("example", "TrackVerified: status = $status; token = ${token?.toJson()}")
@@ -139,6 +131,14 @@ class MainActivity : AppCompatActivity() {
 
         createButton("setExpectedJurisdiction") {
             Radar.setExpectedJurisdiction("US", "CA")
+        }
+
+        createButton("startVerifyServer") {
+            Radar.startVerifyServer()
+        }
+
+        createButton("stopVerifyServer") {
+            Radar.stopVerifyServer()
         }
 
         createButton("trackOnce") {

--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -123,6 +123,14 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        createButton("startVerifyServer") {
+            Radar.startVerifyServer()
+        }
+
+        createButton("stopTrackingVerified") {
+            Radar.stopVerifyServer()
+        }
+
         createButton("trackVerified") {
             Radar.trackVerified(false) { status, token ->
                 Log.v("example", "TrackVerified: status = $status; token = ${token?.toJson()}")

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.18.8-beta.1'
+    radarVersion = '3.18.8-beta.2'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.19.0-beta.1'
+    radarVersion = '3.18.8-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: "org.jetbrains.dokka"
 apply plugin: 'io.radar.mvnpublish'
 
 ext {
-    radarVersion = '3.18.5'
+    radarVersion = '3.19.0-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation "androidx.fragment:fragment:1.3.0"
     compileOnly "com.huawei.hms:location:6.4.0.300"
     compileOnly "com.google.android.play:integrity:1.2.0"
+    compileOnly 'org.nanohttpd:nanohttpd:2.3.1'
     testImplementation "androidx.test.ext:junit:1.1.5"
     testImplementation "org.robolectric:robolectric:4.10"
     testImplementation 'org.json:json:20211205'

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -471,6 +471,7 @@ object Radar {
     private lateinit var replayBuffer: RadarReplayBuffer
     internal lateinit var batteryManager: RadarBatteryManager
     private lateinit var verificationManager: RadarVerificationManager
+    private lateinit var verifyServer: RadarVerifyServer
 
     /**
      * Initializes the Radar SDK. Call this method from the main thread in `Application.onCreate()` before calling any other Radar methods.
@@ -1148,6 +1149,54 @@ object Radar {
         }
 
         this.verificationManager.setExpectedJurisdiction(countryCode, stateCode)
+    }
+
+    /**
+     * Starts the Radar Verify companion app server.
+     *
+     * Note that you must configure SSL pinning before calling this method.
+     *
+     * @see [](https://radar.com/documentation/fraud)
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @JvmStatic
+    fun startVerifyServer() {
+        if (!initialized) {
+            return
+        }
+        this.logger.i("startVerifyServer()", RadarLogType.SDK_CALL)
+
+        if (!this::verificationManager.isInitialized) {
+            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+        }
+        if (!this::verifyServer.isInitialized) {
+            this.verifyServer = RadarVerifyServer(this.context, this.logger)
+        }
+
+        this.verifyServer.start()
+    }
+
+    /**
+     * Stops the Radar Verify companion app server.
+     *
+     * @see [](https://radar.com/documentation/fraud)
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @JvmStatic
+    fun stopVerifyServer() {
+        if (!initialized) {
+            return
+        }
+        this.logger.i("stopVerifyServer()", RadarLogType.SDK_CALL)
+
+        if (!this::verificationManager.isInitialized) {
+            return
+        }
+        if (!this::verifyServer.isInitialized) {
+            return
+        }
+
+        this.verifyServer.stop()
     }
 
     /**

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -338,12 +338,16 @@ internal class RadarVerificationManager(
     fun stopTrackingVerified() {
         this.started = false
 
-        networkCallback?.let {
-            connectivityManager.unregisterNetworkCallback(it)
-        }
+        try {
+            networkCallback?.let {
+                connectivityManager.unregisterNetworkCallback(it)
+            }
 
-        runnable?.let {
-            handler.removeCallbacks(it)
+            runnable?.let {
+                handler.removeCallbacks(it)
+            }
+        } catch (e: Exception) {
+            Radar.logger.e("Error unregistering callbacks", Radar.RadarLogType.SDK_EXCEPTION, e)
         }
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifyServer.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifyServer.kt
@@ -1,6 +1,8 @@
 package io.radar.sdk
 
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.provider.Settings
 import androidx.annotation.RequiresApi
 import fi.iki.elonen.NanoHTTPD
@@ -99,4 +101,39 @@ internal class RadarVerifyServer(
             return response
         }
     }
+
+    override fun start() {
+        super.start()
+
+        startForegroundService()
+    }
+
+    override fun stop() {
+        super.stop()
+
+        stopForegroundService()
+    }
+
+    private fun startForegroundService() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val intent = Intent(context, RadarForegroundService::class.java).apply {
+                action = "start"
+                putExtra("title", "Location checks started")
+                putExtra("text", "Please return to the browser to continue")
+            }
+
+            context.startForegroundService(intent)
+        }
+    }
+
+    private fun stopForegroundService() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val stopIntent = Intent(context, RadarForegroundService::class.java).apply {
+                action = "stop"
+            }
+
+            context.startService(stopIntent)
+        }
+    }
+
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifyServer.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifyServer.kt
@@ -62,15 +62,15 @@ internal class RadarVerifyServer(
             val latch = CountDownLatch(1)
             var response = newFixedLengthResponse(Status.INTERNAL_ERROR, "application/json", null)
 
-            if (isAdbEnabled(context)) {
-                val resStr = "{\"meta\":{\"code\":403,\"error\":\"ERROR_FORBIDDEN\"}}"
-                response = newFixedLengthResponse(Status.FORBIDDEN, "application/json", resStr)
-                latch.countDown()
-            } else {
+            // if (isAdbEnabled(context)) {
+            //     val resStr = "{\"meta\":{\"code\":403,\"error\":\"ERROR_FORBIDDEN\"}}"
+            //     response = newFixedLengthResponse(Status.FORBIDDEN, "application/json", resStr)
+            //     latch.countDown()
+            // } else {
                 Radar.trackVerified { status, token ->
                     if (status == Radar.RadarStatus.SUCCESS) {
-                        val userStr = token?.user?.toJson().toString()
-                        val eventsStr = token?.events?.joinToString(separator = ",", prefix = "[", postfix = "]") { it.toJson().toString() }
+                        val userStr = token?.user?.toRawJson().toString()
+                        val eventsStr = token?.events?.joinToString(separator = ",", prefix = "[", postfix = "]") { it.toRawJson().toString() }
                         val resStr = "{\"meta\":{\"code\":200},\"user\":$userStr,\"events\":$eventsStr}"
                         response = newFixedLengthResponse(Status.OK, "application/json", resStr)
                     } else if (status == Radar.RadarStatus.ERROR_PERMISSIONS) {
@@ -86,7 +86,7 @@ internal class RadarVerifyServer(
 
                     latch.countDown()
                 }
-            }
+            // }
 
             latch.await()
 

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifyServer.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifyServer.kt
@@ -1,0 +1,102 @@
+package io.radar.sdk
+
+import android.content.Context
+import android.provider.Settings
+import androidx.annotation.RequiresApi
+import fi.iki.elonen.NanoHTTPD
+import fi.iki.elonen.NanoHTTPD.Response.Status
+import java.util.concurrent.CountDownLatch
+
+@RequiresApi(21)
+internal class RadarVerifyServer(
+    private val context: Context,
+    private val logger: RadarLogger,
+) : NanoHTTPD(52516) {
+
+    private fun addHeaders(response: Response?) {
+        response?.addHeader(
+            "Access-Control-Allow-Headers",
+            "Content-Type, Accept, Authorization, X-Radar-Device-Type, X-Radar-SDK-Version"
+        )
+        response?.addHeader(
+            "Access-Control-Allow-Origin",
+            "*")
+        response?.addHeader(
+            "Access-Control-Allow-Methods",
+            "GET, OPTIONS")
+    }
+
+    fun isAdbEnabled(context: Context): Boolean {
+        var adb = 0
+        try {
+            adb = Settings.Secure.getInt(context.contentResolver, Settings.Secure.ADB_ENABLED)
+        } catch (e: Settings.SettingNotFoundException) {
+
+        }
+        return adb == 1
+    }
+
+    override fun serve(session: IHTTPSession): Response {
+        val method = session.method
+        val uri = session.uri
+
+        if (Method.OPTIONS == method) {
+            val response = newFixedLengthResponse(Status.OK, "application/json", null)
+            addHeaders(response)
+            return response
+        } else if (Method.GET == method && "/v1/verify" == uri) {
+            val publishableKey = session.headers["authorization"]
+            if (publishableKey == null) {
+                val response = newFixedLengthResponse(Status.FORBIDDEN, "application/json", null)
+                addHeaders(response)
+                return response
+            }
+
+            val userId = session.parameters.get("Authorization")?.get(0)
+            val description = session.parameters.get("Authorization")?.get(0)
+
+            Radar.initialize(context, publishableKey)
+            Radar.setUserId(userId)
+            Radar.setDescription(description)
+
+            val latch = CountDownLatch(1)
+            var response = newFixedLengthResponse(Status.INTERNAL_ERROR, "application/json", null)
+
+            if (isAdbEnabled(context)) {
+                val resStr = "{\"meta\":{\"code\":403,\"error\":\"ERROR_FORBIDDEN\"}}"
+                response = newFixedLengthResponse(Status.FORBIDDEN, "application/json", resStr)
+                latch.countDown()
+            } else {
+                Radar.trackVerified { status, token ->
+                    if (status == Radar.RadarStatus.SUCCESS) {
+                        val userStr = token?.user?.toJson().toString()
+                        val eventsStr = token?.events?.joinToString(separator = ",", prefix = "[", postfix = "]") { it.toJson().toString() }
+                        val resStr = "{\"meta\":{\"code\":200},\"user\":$userStr,\"events\":$eventsStr}"
+                        response = newFixedLengthResponse(Status.OK, "application/json", resStr)
+                    } else if (status == Radar.RadarStatus.ERROR_PERMISSIONS) {
+                        val resStr = "{\"meta\":{\"code\":400,\"error\":\"ERROR_PERMISSIONS\"}}"
+                        response = newFixedLengthResponse(Status.BAD_REQUEST, "application/json", resStr)
+                    } else if (status == Radar.RadarStatus.ERROR_LOCATION) {
+                        val resStr = "{\"meta\":{\"code\":400,\"error\":\"ERROR_LOCATION\"}}"
+                        response = newFixedLengthResponse(Status.BAD_REQUEST, "application/json", resStr)
+                    } else if (status == Radar.RadarStatus.ERROR_NETWORK) {
+                        val resStr = "{\"meta\":{\"code\":400,\"error\":\"ERROR_NETWORK\"}}"
+                        response = newFixedLengthResponse(Status.BAD_REQUEST, "application/json", resStr)
+                    }
+
+                    latch.countDown()
+                }
+            }
+
+            latch.await()
+
+            addHeaders(response)
+
+            return response
+        } else {
+            val response = newFixedLengthResponse(Status.NOT_FOUND, "application/json", null)
+            addHeaders(response)
+            return response
+        }
+    }
+}

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -110,11 +110,6 @@ class RadarEvent(
      * The metadata of the event. Present on conversions only.
      */
     val metadata: JSONObject?,
-
-    /**
-     * The raw JSON for the event.
-     */
-    val rawJson: JSONObject?,
 ) {
 
     /**
@@ -300,7 +295,7 @@ class RadarEvent(
 
             val event = RadarEvent(
                 id, createdAt, actualCreatedAt, live, type, conversionName, geofence, place, region, beacon, trip, fraud,
-                alternatePlaces, verifiedPlace, verification, confidence, duration, location, replayed, metadata, rawJson = obj,
+                alternatePlaces, verifiedPlace, verification, confidence, duration, location, replayed, metadata,
             )
 
             return event
@@ -326,18 +321,6 @@ class RadarEvent(
             val arr = JSONArray()
             events.forEach { event ->
                 arr.put(event.toJson())
-            }
-            return arr
-        }
-
-        fun toRawJson(events: Array<RadarEvent> ?): JSONArray? {
-            if (events == null) {
-                return null
-            }
-
-            val arr = JSONArray()
-            events.forEach { event ->
-                arr.put(event.toRawJson())
             }
             return arr
         }
@@ -400,10 +383,6 @@ class RadarEvent(
         obj.putOpt(FIELD_METADATA, metadata)
 
         return obj
-    }
-
-    fun toRawJson(): JSONObject? {
-        return rawJson
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -112,7 +112,7 @@ class RadarEvent(
     val metadata: JSONObject?,
 
     /**
-     * The raw JSON of the event.
+     * The raw JSON for the event.
      */
     val rawJson: JSONObject?,
 ) {

--- a/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarEvent.kt
@@ -109,7 +109,12 @@ class RadarEvent(
     /**
      * The metadata of the event. Present on conversions only.
      */
-    val metadata: JSONObject?
+    val metadata: JSONObject?,
+
+    /**
+     * The raw JSON of the event.
+     */
+    val rawJson: JSONObject?,
 ) {
 
     /**
@@ -295,7 +300,7 @@ class RadarEvent(
 
             val event = RadarEvent(
                 id, createdAt, actualCreatedAt, live, type, conversionName, geofence, place, region, beacon, trip, fraud,
-                alternatePlaces, verifiedPlace, verification, confidence, duration, location, replayed, metadata
+                alternatePlaces, verifiedPlace, verification, confidence, duration, location, replayed, metadata, rawJson = obj,
             )
 
             return event
@@ -321,6 +326,18 @@ class RadarEvent(
             val arr = JSONArray()
             events.forEach { event ->
                 arr.put(event.toJson())
+            }
+            return arr
+        }
+
+        fun toRawJson(events: Array<RadarEvent> ?): JSONArray? {
+            if (events == null) {
+                return null
+            }
+
+            val arr = JSONArray()
+            events.forEach { event ->
+                arr.put(event.toRawJson())
             }
             return arr
         }
@@ -383,6 +400,10 @@ class RadarEvent(
         obj.putOpt(FIELD_METADATA, metadata)
 
         return obj
+    }
+
+    fun toRawJson(): JSONObject? {
+        return rawJson
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/model/RadarUser.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarUser.kt
@@ -125,11 +125,6 @@ class RadarUser(
     The user's current activity type.
      */
     val activityType: Radar.RadarActivityType?,
-
-    /**
-    The raw JSON for the user.
-     */
-    val rawJson: JSONObject?
 ) {
     internal companion object {
         private const val FIELD_ID = "_id"
@@ -229,7 +224,6 @@ class RadarUser(
                 debug,
                 fraud,
                 activityType,
-                rawJson = obj,
             )
         }
     }
@@ -268,8 +262,6 @@ class RadarUser(
         return obj
     }
 
-    fun toRawJson(): JSONObject? {
-        return rawJson
-    }
+
 
 }

--- a/sdk/src/main/java/io/radar/sdk/model/RadarUser.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarUser.kt
@@ -124,7 +124,12 @@ class RadarUser(
     /**
     The user's current activity type.
      */
-    val activityType: Radar.RadarActivityType?
+    val activityType: Radar.RadarActivityType?,
+
+    /**
+    The raw JSON for the user.
+     */
+    val rawJson: JSONObject?
 ) {
     internal companion object {
         private const val FIELD_ID = "_id"
@@ -223,7 +228,8 @@ class RadarUser(
                 trip,
                 debug,
                 fraud,
-                activityType
+                activityType,
+                rawJson = obj,
             )
         }
     }
@@ -260,6 +266,10 @@ class RadarUser(
         obj.putOpt(FIELD_FRAUD, this.fraud?.toJson())
         obj.putOpt(FIELD_ACTIVITY_TYPE,this.activityType?.toString())
         return obj
+    }
+
+    fun toRawJson(): JSONObject? {
+        return rawJson
     }
 
 }

--- a/sdk/src/main/java/io/radar/sdk/model/RadarVerifiedLocationToken.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarVerifiedLocationToken.kt
@@ -50,6 +50,11 @@ class RadarVerifiedLocationToken(
      * The Radar ID of the location check.
      */
     val _id: String,
+
+    /**
+    The raw JSON for the user.
+     */
+    val rawJson: JSONObject?
 ) {
     internal companion object {
         private const val FIELD_USER = "user"
@@ -83,7 +88,7 @@ class RadarVerifiedLocationToken(
                 return null
             }
 
-            return RadarVerifiedLocationToken(user, events, token, expiresAt, expiresIn, passed, failureReasons, id)
+            return RadarVerifiedLocationToken(user, events, token, expiresAt, expiresIn, passed, failureReasons, id, rawJson = obj)
         }
     }
 
@@ -100,6 +105,10 @@ class RadarVerifiedLocationToken(
         obj.putOpt(FIELD_FAILURE_REASONS, failureReasonsArr)
         obj.putOpt(FIELD_ID, this._id)
         return obj
+    }
+
+    fun toRawJson(): JSONObject? {
+        return rawJson
     }
 
 }


### PR DESCRIPTION
- expose `startVerifyServer()` and `stopVerifyServer()`, allowing customers to turn their Android app into a "companion app" (https://radar.com/documentation/fraud#web-and-desktop) for `trackVerified()` and `startTrackingVerified()` on mobile
- uses https://github.com/NanoHttpd/nanohttpd for the server. to make this optional, we use a `compileOnly` dependency (like the Integrity API dependency)
- app and sever are kept alive using a foreground service