### PR TITLE
FENCE-2308: Add batching options to tracking options

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext {
-    radarVersion = '3.23.3'
+    radarVersion = '3.24.0-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3694,6 +3694,21 @@ object Radar {
     }
 
     @JvmStatic
+    internal fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions) {
+        replayBuffer.addToBatch(batchParams, options)
+    }
+
+    @JvmStatic
+    internal fun shouldFlushBatch(options: RadarTrackingOptions): Boolean {
+        return replayBuffer.shouldFlushBatch(options)
+    }
+
+    @JvmStatic
+    internal fun flushBatch(): Boolean {
+        return replayBuffer.flushBatch()
+    }
+
+    @JvmStatic
     internal fun loadReplayBufferFromSharedPreferences() {
         replayBuffer.loadFromSharedPreferences()
         val replayCount = replayBuffer.getSize()

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -3693,17 +3693,14 @@ object Radar {
         replayBuffer.write(replayParams)
     }
 
-    @JvmStatic
     internal fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions) {
         replayBuffer.addToBatch(batchParams, options)
     }
 
-    @JvmStatic
     internal fun shouldFlushBatch(options: RadarTrackingOptions): Boolean {
         return replayBuffer.shouldFlushBatch(options)
     }
 
-    @JvmStatic
     internal fun flushBatch(): Boolean {
         return replayBuffer.flushBatch()
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -610,7 +610,7 @@ data class RadarTrackingOptions(
                 useMotion = obj.optBoolean(KEY_USE_MOTION),
                 usePressure = obj.optBoolean(KEY_USE_PRESSURE),
                 batchInterval = obj.optInt(KEY_BATCH_INTERVAL),
-                batchSize =  obj.optInt(KEY_BATCH_SIZE)
+                batchSize = obj.optInt(KEY_BATCH_SIZE)
             )
         }
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -123,6 +123,16 @@ data class RadarTrackingOptions(
      * Determines whether to collect pressure data.
      */
     var usePressure: Boolean,
+
+    /**
+     * Determines the time interval between batch events, in seconds.
+     */
+    var batchInterval: Int,
+
+    /**
+     * Determines the number of events per batch.
+     */
+    var batchSize: Int,
 ) {
 
     /**
@@ -433,7 +443,9 @@ data class RadarTrackingOptions(
             foregroundServiceEnabled = true,
             beacons = false,
             useMotion = false,
-            usePressure = false
+            usePressure = false,
+            batchInterval = 0,
+            batchSize = 0
         )
 
         /**
@@ -464,7 +476,9 @@ data class RadarTrackingOptions(
             foregroundServiceEnabled = false,
             beacons = false,
             useMotion = false,
-            usePressure = false
+            usePressure = false,
+            batchInterval = 0,
+            batchSize = 0
         )
 
         /**
@@ -495,7 +509,9 @@ data class RadarTrackingOptions(
             foregroundServiceEnabled = false,
             beacons = false,
             useMotion = false,
-            usePressure = false
+            usePressure = false,
+            batchInterval = 0,
+            batchSize = 0
         )
 
         internal const val KEY_DESIRED_STOPPED_UPDATE_INTERVAL = "desiredStoppedUpdateInterval"
@@ -520,6 +536,8 @@ data class RadarTrackingOptions(
         internal const val KEY_BEACONS = "beacons"
         internal const val KEY_USE_MOTION = "useMotion"
         internal const val KEY_USE_PRESSURE = "usePressure"
+        internal const val KEY_BATCH_INTERVAL = "batchInterval"
+        internal const val KEY_BATCH_SIZE = "batchSize"
         @JvmStatic
         fun fromJson(obj: JSONObject): RadarTrackingOptions {
             val desiredAccuracy = if (obj.has(KEY_DESIRED_ACCURACY) && obj.get(KEY_DESIRED_ACCURACY) is String) {
@@ -590,7 +608,9 @@ data class RadarTrackingOptions(
                 foregroundServiceEnabled = obj.optBoolean(KEY_FOREGROUND_SERVICE_ENABLED, false),
                 beacons = obj.optBoolean(KEY_BEACONS),
                 useMotion = obj.optBoolean(KEY_USE_MOTION),
-                usePressure = obj.optBoolean(KEY_USE_PRESSURE)
+                usePressure = obj.optBoolean(KEY_USE_PRESSURE),
+                batchInterval = obj.optInt(KEY_BATCH_INTERVAL),
+                batchSize =  obj.optInt(KEY_BATCH_SIZE)
             )
         }
     }
@@ -619,6 +639,8 @@ data class RadarTrackingOptions(
         obj.put(KEY_BEACONS, beacons)
         obj.put(KEY_USE_MOTION, useMotion)
         obj.put(KEY_USE_PRESSURE, usePressure)
+        obj.put(KEY_BATCH_INTERVAL, batchInterval)
+        obj.put(KEY_BATCH_SIZE, batchSize)
         return obj
     }
 

--- a/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
@@ -12,4 +12,15 @@ internal interface RadarReplayBuffer {
     fun getFlushableReplaysStash(): Flushable<RadarReplay>
 
     fun loadFromSharedPreferences()
+
+    // Batching methods
+    fun addToBatch(batchParams: JSONObject, options: io.radar.sdk.RadarTrackingOptions)
+
+    fun shouldFlushBatch(options: io.radar.sdk.RadarTrackingOptions): Boolean
+
+    fun flushBatch(): Boolean
+
+    fun scheduleBatchTimer(options: io.radar.sdk.RadarTrackingOptions)
+
+    fun cancelBatchTimer()
 }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
@@ -1,5 +1,6 @@
 package io.radar.sdk.util
 
+import io.radar.sdk.RadarTrackingOptions
 import io.radar.sdk.model.RadarReplay
 import org.json.JSONObject
 
@@ -14,13 +15,13 @@ internal interface RadarReplayBuffer {
     fun loadFromSharedPreferences()
 
     // Batching methods
-    fun addToBatch(batchParams: JSONObject, options: io.radar.sdk.RadarTrackingOptions)
+    fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions)
 
-    fun shouldFlushBatch(options: io.radar.sdk.RadarTrackingOptions): Boolean
+    fun shouldFlushBatch(options: RadarTrackingOptions): Boolean
 
     fun flushBatch(): Boolean
 
-    fun scheduleBatchTimer(options: io.radar.sdk.RadarTrackingOptions)
+    fun scheduleBatchTimer(options: RadarTrackingOptions)
 
     fun cancelBatchTimer()
 }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
@@ -1,11 +1,15 @@
 package io.radar.sdk.util
 
+import io.radar.sdk.Radar
 import io.radar.sdk.RadarSettings
+import io.radar.sdk.RadarTrackingOptions
 import io.radar.sdk.model.RadarReplay
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import java.util.concurrent.LinkedBlockingDeque
+import java.util.Timer
+import java.util.TimerTask
 import org.json.JSONObject
 import org.json.JSONArray
 
@@ -18,6 +22,9 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
     }
 
     private val buffer = LinkedBlockingDeque<RadarReplay>(MAXIMUM_CAPACITY)
+    private var batchTimer: Timer? = null
+    private var batchStartTime: Long = 0
+    private var batchCount: Int = 0
 
     override fun getSize(): Int {
         return buffer.size
@@ -73,6 +80,68 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
                 buffer.offer(replay)
             }
         }
+    }
+
+    override fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions) {
+        if (batchCount == 0) {
+            batchStartTime = System.currentTimeMillis()
+        }
+        
+        batchCount++
+        write(batchParams)
+
+        // Schedule timer if interval is set and timer not already running
+        if (options.batchInterval > 0 && batchTimer == null) {
+            scheduleBatchTimer(options)
+        }
+    }
+
+    override fun shouldFlushBatch(options: RadarTrackingOptions): Boolean {
+        // Return false if no batched items
+        if (batchCount == 0) {
+            return false
+        }
+        
+        // Check size limit
+        if (options.batchSize > 0 && batchCount >= options.batchSize) {
+            return true
+        }
+
+        return false
+    }
+
+    override fun flushBatch(): Boolean {
+        if (batchCount == 0) {
+            return false
+        }
+        
+        cancelBatchTimer()
+        batchStartTime = 0
+        batchCount = 0
+        
+        Radar.flushReplays()
+        
+        return true
+    }
+
+    override fun scheduleBatchTimer(options: RadarTrackingOptions) {
+        if (options.batchInterval <= 0) return
+
+        cancelBatchTimer()
+        batchTimer = Timer()
+        batchTimer?.schedule(object : TimerTask() {
+            override fun run() {
+                if (batchCount > 0) {
+                    // Timer fired, trigger flush
+                    flushBatch()
+                }
+            }
+        }, options.batchInterval * 1000L)
+    }
+
+    override fun cancelBatchTimer() {
+        batchTimer?.cancel()
+        batchTimer = null
     }
 
     private fun getSharedPreferences(context: Context): SharedPreferences {


### PR DESCRIPTION
Adds `batchInterval` and `batchSize` to `trackingOptions`
Adds batch handling logic to `RadarReplayBuffer`
Adds batch check to `RadarAPIClient`

**Testing**

1. Added `batchSize` and `batchInterval` parameters to tracking options in project settings
2. Added logging (shown below) 

logs: 
<img width="1193" height="168" alt="Screenshot 2025-10-20 at 2 08 01 PM" src="https://github.com/user-attachments/assets/a2e45ce3-e308-4e30-bd19-7bf23544e041" />

<img width="1341" height="258" alt="Screenshot 2025-10-20 at 2 06 38 PM" src="https://github.com/user-attachments/assets/d2c27b6e-c936-49b2-962e-7d345ed9fa02" />

<img width="1019" height="158" alt="Screenshot 2025-10-20 at 2 17 12 PM" src="https://github.com/user-attachments/assets/f74d6377-5025-4b71-a056-9299efb53c7c" />
