### PR TITLE
FENCE-2717: Add offline event detection and RTO ramping

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -364,6 +364,8 @@ object Radar {
         BEACON_ENTER,
         /** Beacon exit */
         BEACON_EXIT,
+        /** Offline detection*/
+        OFFLINE,
         /** Unknown */
         UNKNOWN
     }
@@ -508,6 +510,7 @@ object Radar {
     private lateinit var verificationManager: RadarVerificationManager
     private lateinit var inAppMessageManager: RadarInAppMessageManager
     internal lateinit var syncManager: RadarSyncManager
+    internal lateinit var offlineEventManager: RadarOfflineEventManager
     private var activityLifecycleCallbacks: RadarActivityLifecycleCallbacks? = null
     /**
      * Initializes the Radar SDK. Call this method from the main thread in `Application.onCreate()` before calling any other Radar methods.
@@ -665,6 +668,10 @@ object Radar {
 
         if (!this::syncManager.isInitialized) {
             this.syncManager = RadarSyncManager(this.context, apiClient, logger)
+        }
+
+        if (!this::offlineEventManager.isInitialized) {
+            this.offlineEventManager = RadarOfflineEventManager(this.context, syncManager, logger)
         }
 
         this.logger.i("initialize()", RadarLogType.SDK_CALL)
@@ -4033,6 +4040,7 @@ object Radar {
             RadarLocationSource.MOCK_LOCATION -> "MOCK_LOCATION"
             RadarLocationSource.BEACON_ENTER -> "BEACON_ENTER"
             RadarLocationSource.BEACON_EXIT -> "BEACON_EXIT"
+            RadarLocationSource.OFFLINE -> "OFFLINE_DETECTION"
             else -> "UNKNOWN"
         }
     }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -364,8 +364,6 @@ object Radar {
         BEACON_ENTER,
         /** Beacon exit */
         BEACON_EXIT,
-        /** Offline detection*/
-        OFFLINE,
         /** Unknown */
         UNKNOWN
     }
@@ -4040,7 +4038,6 @@ object Radar {
             RadarLocationSource.MOCK_LOCATION -> "MOCK_LOCATION"
             RadarLocationSource.BEACON_ENTER -> "BEACON_ENTER"
             RadarLocationSource.BEACON_EXIT -> "BEACON_EXIT"
-            RadarLocationSource.OFFLINE -> "OFFLINE_DETECTION"
             else -> "UNKNOWN"
         }
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -25,6 +25,7 @@ import io.radar.sdk.model.RadarTrip
 import io.radar.sdk.model.RadarUser
 import io.radar.sdk.model.RadarVerifiedLocationToken
 import io.radar.sdk.model.RadarCoordinate
+import io.radar.sdk.model.RadarMeta
 import io.radar.sdk.model.RadarTripLeg
 import org.json.JSONArray
 import org.json.JSONException
@@ -506,6 +507,18 @@ internal class RadarApiClient(
                         RadarState.setLastFailedStoppedLocation(context, location)
                     }
 
+                    // Generate offline events (gated internally by offlineEventGenerationEnabled)
+                    Radar.offlineEventManager.handleTrackFailure(location)
+
+                    // Apply offline remote tracking options if useOfflineRTOUpdates is enabled
+                    if (RadarSettings.getSdkConfiguration(context).useOfflineRTOUpdates) {
+                        val offlineOptions = Radar.offlineEventManager.updateTrackingOptions(location)
+                        if (offlineOptions != null) {
+                            val offlineMeta = RadarMeta(offlineOptions, null)
+                            locationManager.updateTrackingFromMeta(offlineMeta)
+                        }
+                    }
+
                     Radar.sendError(status)
 
                     callback?.onComplete(status)
@@ -537,6 +550,7 @@ internal class RadarApiClient(
                 val token = RadarVerifiedLocationToken.fromJson(res)
 
                 if (user != null) {
+                    RadarState.setLastUser(context, user)
                     val inGeofences = user.geofences != null && user.geofences.isNotEmpty()
                     val atPlace = user.place != null
                     val canExit = inGeofences || atPlace

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -574,10 +574,16 @@ internal class RadarLocationManager(
         callCallbacks(RadarStatus.SUCCESS, location)
 
         val sdkConfiguration = RadarSettings.getSdkConfiguration(context)
-        if (sdkConfiguration.useSyncRegion && !Radar.syncManager.hasSyncedRegion()) {
-            Radar.syncManager.fetchSyncRegion()
+        if (sdkConfiguration.useSyncRegion) {
+            if (!Radar.syncManager.hasSyncedRegion()) {
+                Radar.syncManager.fetchSyncRegion()
+            } else if (sdkConfiguration.offlineEventGenerationEnabled
+                && (Radar.syncManager.isOutsideSyncedRegion(location) ||
+                        Radar.syncManager.isNearSyncedRegionBoundary(location))) {
+                Radar.syncManager.fetchSyncRegion()
+            }
         }
-
+        
         var sendLocation = location
 
         val lastFailedStoppedLocation = RadarState.getLastFailedStoppedLocation(context)

--- a/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarLocationManager.kt
@@ -583,7 +583,7 @@ internal class RadarLocationManager(
                 Radar.syncManager.fetchSyncRegion()
             }
         }
-        
+
         var sendLocation = location
 
         val lastFailedStoppedLocation = RadarState.getLastFailedStoppedLocation(context)

--- a/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
@@ -7,7 +7,6 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Date
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicReference
 
 internal class RadarOfflineEventManager(
     private val context: Context,
@@ -15,10 +14,12 @@ internal class RadarOfflineEventManager(
     private val logger: RadarLogger
 ) {
     private val lock = Any()
-    val offlineGeofenceIds = AtomicReference<Set<String>?>()
-
+    private var _offlineGeofenceIds: Set<String>? = null
+    private var offlineGeofenceIds: Set<String>?
+        get() = synchronized(lock) { _offlineGeofenceIds }
+        set(value) = synchronized(lock) { _offlineGeofenceIds = value }
     fun reset() {
-        offlineGeofenceIds.set(null)
+        offlineGeofenceIds = null
     }
 
     // region Event generation
@@ -31,7 +32,7 @@ internal class RadarOfflineEventManager(
         val baselineIds = state.lastSyncedGeofenceIds.toSet()
 
 
-        val effectiveIds = offlineGeofenceIds.get() ?: baselineIds
+        val effectiveIds = offlineGeofenceIds ?: baselineIds
 
         val entries = syncManager.getGeofenceEntries(location, effectiveIds)
         val exits = syncManager.getGeofenceExits(location, effectiveIds)
@@ -56,7 +57,7 @@ internal class RadarOfflineEventManager(
         }
 
         val currentGeofences = syncManager.getGeofences(location)
-        offlineGeofenceIds.set(currentGeofences.map { it._id }.toSet())
+        offlineGeofenceIds = currentGeofences.map { it._id }.toSet()
 
         val user = buildSyntheticUser(location, currentGeofences)
         callback(events, user, location)

--- a/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
@@ -174,18 +174,12 @@ internal class RadarOfflineEventManager(
             put("geofences", RadarGeofence.toJson(geofences.toTypedArray()))
             put("stopped", RadarState.getStopped(context))
             put("foreground", RadarActivityLifecycleCallbacks.foreground)
-            put("source", "OFFLINE_DETECTION")
 
             cachedUser?._id?.let { put("_id", it) }
             cachedUser?.userId?.let { put("userId", it) }
             cachedUser?.deviceId?.let { put("deviceId", it) }
             cachedUser?.description?.let { put("description", it) }
             cachedUser?.metadata?.let { put("metadata", it) }
-            cachedUser?.country?.let { put("country", it.toJson()) }
-            cachedUser?.state?.let { put("state", it.toJson()) }
-            cachedUser?.dma?.let { put("dma", it.toJson()) }
-            cachedUser?.postalCode?.let { put("postalCode", it.toJson()) }
-            cachedUser?.trip?.let { put("trip", it.toJson()) }
         }
         return RadarUser.fromJson(userJson)
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
@@ -1,0 +1,194 @@
+package io.radar.sdk
+
+import android.content.Context
+import android.location.Location
+import io.radar.sdk.model.*
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.Date
+import java.util.UUID
+
+internal class RadarOfflineEventManager(
+    private val context: Context,
+    private val syncManager: RadarSyncManager,
+    private val logger: RadarLogger
+) {
+    private val lock = Any()
+    private var offlineGeofenceIds: Set<String> = emptySet()
+
+    fun reset() {
+        synchronized(lock) {
+            offlineGeofenceIds = emptySet()
+        }
+    }
+
+    // region Event generation
+
+    fun generateEvents(
+        location: Location,
+        callback: (List<RadarEvent>, RadarUser?, Location) -> Unit
+    ) {
+        val state = syncManager.syncStore.read() ?: RadarSyncState()
+        val baselineIds = state.lastSyncedGeofenceIds.toSet()
+
+
+       val effectiveIds = synchronized(lock) {
+           offlineGeofenceIds.ifEmpty { baselineIds }
+       }
+
+        val entries = syncManager.getGeofenceEntries(location, effectiveIds)
+        val exits = syncManager.getGeofenceExits(location, effectiveIds)
+
+        val isoString = RadarUtils.dateToISOString(Date()) ?: return
+        val isLive = (RadarSettings.getPublishableKey(context) ?: "").startsWith("prj_live")
+
+        val events = mutableListOf<RadarEvent>()
+
+        for (geofence in entries) {
+            makeGeofenceEvent("user.entered_geofence", geofence, location, isoString, isLive)?.let {
+                events.add(it)
+                logger.i("OfflineEventManager: Generated geofence entry for ${geofence._id}")
+            }
+        }
+
+        for (geofence in exits) {
+            makeGeofenceEvent("user.exited_geofence", geofence, location, isoString, isLive)?.let {
+                events.add(it)
+                logger.i("OfflineEventManager: Generated geofence exit for ${geofence._id}")
+            }
+        }
+
+        val currentGeofences = syncManager.getGeofences(location)
+        synchronized(lock) {
+            offlineGeofenceIds = currentGeofences.map { it._id }.toSet()
+        }
+
+        val user = buildSyntheticUser(location, currentGeofences)
+        callback(events, user, location)
+    }
+
+    fun handleTrackFailure(location: Location) {
+        val sdkConfig = RadarSettings.getSdkConfiguration(context)
+        if (!sdkConfig.offlineEventGenerationEnabled) return
+
+        generateEvents(location) { events, user, _ ->
+            if (events.isNotEmpty() && user != null) {
+                Radar.sendEvents(events.toTypedArray(), user)
+            }
+        }
+    }
+
+    // endregion
+
+
+    // region Tracking options ramp-up/down
+
+    fun updateTrackingOptions(geofenceTags: List<String>): RadarTrackingOptions? {
+        val sdkConfig = RadarSettings.getSdkConfiguration(context)
+        val remoteOptions = sdkConfig.remoteTrackingOptions
+
+        val rampUpTags = RadarRemoteTrackingOptions.geofenceTags("inGeofence", remoteOptions)
+        val inRampedUpGeofences = if (rampUpTags != null) {
+            rampUpTags.toSet().intersect(geofenceTags.toSet()).isNotEmpty()
+        } else {
+            false
+        }
+
+        return when {
+            inRampedUpGeofences -> {
+                logger.d("OfflineEventManager: Ramping up tracking options")
+                RadarRemoteTrackingOptions.trackingOptions("inGeofence", remoteOptions)
+            }
+            Radar.getTripOptions() != null -> {
+                val onTripOptions = RadarRemoteTrackingOptions.trackingOptions("onTrip", remoteOptions)
+                if (onTripOptions != null) {
+                    logger.d("OfflineEventManager: Using on-trip tracking options")
+                    onTripOptions
+                } else {
+                    logger.d("OfflineEventManager: Using default tracking options")
+                    RadarRemoteTrackingOptions.trackingOptions("default", remoteOptions)
+                }
+            }
+            else -> {
+                logger.d("OfflineEventManager: Using default tracking options")
+                RadarRemoteTrackingOptions.trackingOptions("default", remoteOptions)
+            }
+        }
+    }
+
+    fun updateTrackingOptions(location: Location): RadarTrackingOptions? {
+        val currentGeofences = syncManager.getGeofences(location)
+        val tags = currentGeofences.mapNotNull { it.tag }
+        return updateTrackingOptions(tags)
+    }
+
+    // endregion
+
+
+    // region Private helpers
+
+    private fun makeGeofenceEvent(
+        type: String,
+        geofence: RadarGeofence,
+        location: Location,
+        isoDate: String,
+        live: Boolean
+    ): RadarEvent? {
+        val eventJson = JSONObject().apply {
+            put("_id", "${geofence._id}_offline_${UUID.randomUUID()}")
+            put("createdAt", isoDate)
+            put("actualCreatedAt", isoDate)
+            put("live", live)
+            put("type", type)
+            put("geofence", geofence.toJson())
+            put("verification", 0)
+            put("confidence", 1)
+            put("duration", 0)
+            put("location", JSONObject().apply {
+                put("coordinates", JSONArray().apply {
+                    put(location.longitude)
+                    put(location.latitude)
+                })
+            })
+            put("locationAccuracy", location.accuracy)
+            put("replayed", false)
+            put("metadata", JSONObject().apply { put("offline", true) })
+        }
+        return RadarEvent.fromJson(eventJson)
+    }
+
+    private fun buildSyntheticUser(
+        location: Location,
+        geofences: List<RadarGeofence>
+    ): RadarUser? {
+        val cachedUser = RadarState.getLastUser(context)
+
+        val userJson = JSONObject().apply {
+            put("location", JSONObject().apply {
+                put("coordinates", JSONArray().apply {
+                    put(location.longitude)
+                    put(location.latitude)
+                })
+            })
+            put("locationAccuracy", location.accuracy)
+            put("geofences", RadarGeofence.toJson(geofences.toTypedArray()))
+            put("stopped", RadarState.getStopped(context))
+            put("foreground", RadarActivityLifecycleCallbacks.foreground)
+            put("source", "OFFLINE_DETECTION")
+
+            cachedUser?._id?.let { put("_id", it) }
+            cachedUser?.userId?.let { put("userId", it) }
+            cachedUser?.deviceId?.let { put("deviceId", it) }
+            cachedUser?.description?.let { put("description", it) }
+            cachedUser?.metadata?.let { put("metadata", it) }
+            cachedUser?.country?.let { put("country", it.toJson()) }
+            cachedUser?.state?.let { put("state", it.toJson()) }
+            cachedUser?.dma?.let { put("dma", it.toJson()) }
+            cachedUser?.postalCode?.let { put("postalCode", it.toJson()) }
+            cachedUser?.trip?.let { put("trip", it.toJson()) }
+        }
+        return RadarUser.fromJson(userJson)
+    }
+
+    // endregion
+}

--- a/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
@@ -14,11 +14,11 @@ internal class RadarOfflineEventManager(
     private val logger: RadarLogger
 ) {
     private val lock = Any()
-    private var offlineGeofenceIds: Set<String> = emptySet()
+    private var offlineGeofenceIds: Set<String>? = null
 
     fun reset() {
         synchronized(lock) {
-            offlineGeofenceIds = emptySet()
+            offlineGeofenceIds = null
         }
     }
 
@@ -33,7 +33,7 @@ internal class RadarOfflineEventManager(
 
 
        val effectiveIds = synchronized(lock) {
-           offlineGeofenceIds.ifEmpty { baselineIds }
+           offlineGeofenceIds ?: baselineIds
        }
 
         val entries = syncManager.getGeofenceEntries(location, effectiveIds)

--- a/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarOfflineEventManager.kt
@@ -7,6 +7,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Date
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 
 internal class RadarOfflineEventManager(
     private val context: Context,
@@ -14,12 +15,10 @@ internal class RadarOfflineEventManager(
     private val logger: RadarLogger
 ) {
     private val lock = Any()
-    private var offlineGeofenceIds: Set<String>? = null
+    val offlineGeofenceIds = AtomicReference<Set<String>?>()
 
     fun reset() {
-        synchronized(lock) {
-            offlineGeofenceIds = null
-        }
+        offlineGeofenceIds.set(null)
     }
 
     // region Event generation
@@ -32,9 +31,7 @@ internal class RadarOfflineEventManager(
         val baselineIds = state.lastSyncedGeofenceIds.toSet()
 
 
-       val effectiveIds = synchronized(lock) {
-           offlineGeofenceIds ?: baselineIds
-       }
+        val effectiveIds = offlineGeofenceIds.get() ?: baselineIds
 
         val entries = syncManager.getGeofenceEntries(location, effectiveIds)
         val exits = syncManager.getGeofenceExits(location, effectiveIds)
@@ -59,9 +56,7 @@ internal class RadarOfflineEventManager(
         }
 
         val currentGeofences = syncManager.getGeofences(location)
-        synchronized(lock) {
-            offlineGeofenceIds = currentGeofences.map { it._id }.toSet()
-        }
+        offlineGeofenceIds.set(currentGeofences.map { it._id }.toSet())
 
         val user = buildSyntheticUser(location, currentGeofences)
         callback(events, user, location)
@@ -88,11 +83,7 @@ internal class RadarOfflineEventManager(
         val remoteOptions = sdkConfig.remoteTrackingOptions
 
         val rampUpTags = RadarRemoteTrackingOptions.geofenceTags("inGeofence", remoteOptions)
-        val inRampedUpGeofences = if (rampUpTags != null) {
-            rampUpTags.toSet().intersect(geofenceTags.toSet()).isNotEmpty()
-        } else {
-            false
-        }
+        val inRampedUpGeofences = rampUpTags?.toSet()?.intersect(geofenceTags.toSet())?.isNotEmpty() ?: false
 
         return when {
             inRampedUpGeofences -> {

--- a/sdk/src/main/java/io/radar/sdk/RadarState.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarState.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import io.radar.sdk.model.RadarBeacon
+import io.radar.sdk.model.RadarUser
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -42,6 +43,7 @@ internal object RadarState {
     private const val KEY_LAST_MOTION_ACTIVITY = "last_motion_activity"
     private const val KEY_LAST_PRESSURE = "last_pressure"
     private const val KEY_ALTITUDE_ADJUSTMENTS = "altitude_adjustments"
+    private const val KEY_LAST_USER = "last_user"
 
     private fun getSharedPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences("RadarSDK", Context.MODE_PRIVATE)
@@ -313,4 +315,22 @@ internal object RadarState {
             putString(KEY_ALTITUDE_ADJUSTMENTS, jsonString)
         }
     }
+
+    internal fun getLastUser(context: Context): RadarUser? {
+        val jsonString = getSharedPreferences(context).getString(KEY_LAST_USER, null)
+        val userJson = stringToJsonObject(jsonString) ?: return null
+        return RadarUser.fromJson(userJson)
+    }
+
+    internal fun setLastUser(context: Context, user: RadarUser?) {
+        val jsonString = user?.toJson()?.toString()
+        getSharedPreferences(context).edit {
+            if (jsonString != null) {
+                putString(KEY_LAST_USER, jsonString)
+            } else {
+                remove(KEY_LAST_USER)
+            }
+        }
+    }
+
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarSyncManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSyncManager.kt
@@ -620,6 +620,41 @@ internal class RadarSyncManager(
 
     // endregion
 
+    // region Geofence Diff
+
+    fun getGeofenceEntries(location: Location, against: Set<String>): List<RadarGeofence> {
+        val currentGeofences = getGeofences(location)
+        val currentGeofenceIds = currentGeofences.map { it._id }.toSet()
+        val enteredIds = currentGeofenceIds - against
+        if (enteredIds.isEmpty()) return emptyList()
+
+        val sdkConfig = RadarSettings.getSdkConfiguration(context)
+        val projectStopDetection = sdkConfig.stopDetection
+        val isStopped = RadarState.getStopped(context)
+
+        return currentGeofences.filter { geofence ->
+            if (geofence._id !in enteredIds) return@filter false
+            val requireStop = geofence.stopDetection ?: projectStopDetection
+            if (requireStop && !isStopped) {
+                logger.d("SyncManager: Skipping geofence entry (stop detection, not stopped): ${geofence._id}")
+                return@filter false
+            }
+            true
+        }
+    }
+
+    fun getGeofenceExits(location: Location, against: Set<String>): List<RadarGeofence> {
+        val exitCheckGeofences = getGeofences(location, checkingForExit = true)
+        val exitCheckIds = exitCheckGeofences.map { it._id }.toSet()
+        val exitedIds = against - exitCheckIds
+        if (exitedIds.isEmpty()) return emptyList()
+
+        val allSynced = syncStore.read()?.syncedGeofences ?: return emptyList()
+        return allSynced.filter { it._id in exitedIds }
+    }
+
+    // endregion
+
     // region Server Reconciliation
 
     fun reconcileSyncState(user: RadarUser) {

--- a/sdk/src/main/java/io/radar/sdk/model/RadarRemoteTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarRemoteTrackingOptions.kt
@@ -1,0 +1,59 @@
+package io.radar.sdk.model
+
+import androidx.core.graphics.component1
+import androidx.core.graphics.component2
+import androidx.core.graphics.component3
+import androidx.core.graphics.component4
+import io.radar.sdk.RadarTrackingOptions
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal data class RadarRemoteTrackingOptions(
+    val type: String,
+    val trackingOptions: RadarTrackingOptions,
+    val geofenceTags: List<String>?
+) {
+    companion object {
+        fun fromJson(json: JSONObject): RadarRemoteTrackingOptions? {
+            val type = json.optString("type") ?: return null
+            val trackingOptionsJson = json.optJSONObject("trackingOptions") ?: return  null
+            val trackingOptions = RadarTrackingOptions.fromJson(trackingOptionsJson)
+
+            val geofenceTags = json.optJSONObject("geofenceTags")?.let { arr ->
+                (0 until arr.length()).mapNotNull { arr.optString(it) }
+            }
+
+            return RadarRemoteTrackingOptions(type, trackingOptions, geofenceTags)
+        }
+
+        fun fromJsonArray(array: JSONArray?): List<RadarRemoteTrackingOptions>? {
+            if (array == null || array.length() == 0) return null
+            return (0 until array.length()).mapNotNull { i ->
+                array.optJSONObject(i)?.let { fromJson(it) }
+            }.ifEmpty { null }
+        }
+
+        fun toJsonArray(options: List<RadarRemoteTrackingOptions>?): JSONArray? {
+            if (options == null) return null
+            return JSONArray().apply {
+                options.forEach { put(it.toJson()) }
+            }
+        }
+
+        fun trackingOptions(forKey: String, options: List<RadarRemoteTrackingOptions>?): RadarTrackingOptions? {
+            return options?.firstOrNull { it.type == forKey }?.trackingOptions
+        }
+
+        fun geofenceTags(forKey: String, options: List<RadarRemoteTrackingOptions>?): List<String>? {
+            return options?.firstOrNull { it.type == forKey }?.geofenceTags
+        }
+    }
+
+    fun toJson(): JSONObject {
+        return JSONObject().apply {
+            put("type", type)
+            put("trackingOptions", trackingOptions.toJson())
+            geofenceTags?.let  { put("geofenceTags", JSONArray(it)) }
+        }
+    }
+}

--- a/sdk/src/main/java/io/radar/sdk/model/RadarRemoteTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarRemoteTrackingOptions.kt
@@ -11,12 +11,15 @@ internal data class RadarRemoteTrackingOptions(
 ) {
     companion object {
         fun fromJson(json: JSONObject): RadarRemoteTrackingOptions? {
-            val type = json.optString("type") ?: return null
+            val type = json.optString("type")
+            if (type.isBlank()) return null
             val trackingOptionsJson = json.optJSONObject("trackingOptions") ?: return  null
             val trackingOptions = RadarTrackingOptions.fromJson(trackingOptionsJson)
 
             val geofenceTags = json.optJSONArray("geofenceTags")?.let { arr ->
-                (0 until arr.length()).mapNotNull { arr.optString(it) }
+                (0 until arr.length())
+                    .map { arr.optString(it) }
+                    .filter { it.isNotBlank() }
             }
 
             return RadarRemoteTrackingOptions(type, trackingOptions, geofenceTags)

--- a/sdk/src/main/java/io/radar/sdk/model/RadarRemoteTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarRemoteTrackingOptions.kt
@@ -1,9 +1,5 @@
 package io.radar.sdk.model
 
-import androidx.core.graphics.component1
-import androidx.core.graphics.component2
-import androidx.core.graphics.component3
-import androidx.core.graphics.component4
 import io.radar.sdk.RadarTrackingOptions
 import org.json.JSONArray
 import org.json.JSONObject
@@ -19,7 +15,7 @@ internal data class RadarRemoteTrackingOptions(
             val trackingOptionsJson = json.optJSONObject("trackingOptions") ?: return  null
             val trackingOptions = RadarTrackingOptions.fromJson(trackingOptionsJson)
 
-            val geofenceTags = json.optJSONObject("geofenceTags")?.let { arr ->
+            val geofenceTags = json.optJSONArray("geofenceTags")?.let { arr ->
                 (0 until arr.length()).mapNotNull { arr.optString(it) }
             }
 

--- a/sdk/src/main/java/io/radar/sdk/model/RadarSdkConfiguration.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarSdkConfiguration.kt
@@ -29,6 +29,9 @@ internal data class RadarSdkConfiguration(
     val bufferGeofenceExits: Boolean = true,
     val defaultGeofenceDwellThreshold: Int = 0,
     val maxReplayBufferSize: Int = DEFAULT_MAX_REPLAY_BUFFER_SIZE,
+    val offlineEventGenerationEnabled: Boolean = false,
+    val useOfflineRTOUpdates: Boolean = false,
+    val remoteTrackingOptions: List<RadarRemoteTrackingOptions>? = null,
 ) {
     companion object {
         private const val MAX_CONCURRENT_JOBS = "maxConcurrentJobs"
@@ -52,6 +55,9 @@ internal data class RadarSdkConfiguration(
         private const val DEFAULT_GEOFENCE_DWELL_THRESHOLD = "defaultGeofenceDwellThreshold"
         private const val MAX_REPLAY_BUFFER_SIZE = "maxReplayBufferSize"
         const val DEFAULT_MAX_REPLAY_BUFFER_SIZE = 120
+        private const val OFFLINE_EVENT_GENERATION_ENABLED = "offlineEventGenerationEnabled"
+        private const val USE_OFFLINE_RTO_UPDATES = "useOfflineRTOUpdates"
+        private const val REMOTE_TRACKING_OPTIONS = "remoteTrackingOptions"
 
         fun fromJson(json: JSONObject?): RadarSdkConfiguration {
             // set json as empty object if json is null, which uses fallback values
@@ -84,7 +90,10 @@ internal data class RadarSdkConfiguration(
                 config.optBoolean(BUFFER_GEOFENCE_EXITS, true),
                 config.optInt(DEFAULT_GEOFENCE_DWELL_THRESHOLD, 0),
                 validatedMaxReplayBufferSize,
-            )
+                config.optBoolean(OFFLINE_EVENT_GENERATION_ENABLED, false),
+                config.optBoolean(USE_OFFLINE_RTO_UPDATES, false),
+                RadarRemoteTrackingOptions.fromJsonArray(config.optJSONArray(REMOTE_TRACKING_OPTIONS)),
+                )
         }
 
         fun updateSdkConfigurationFromServer(context: Context) {
@@ -121,6 +130,9 @@ internal data class RadarSdkConfiguration(
             putOpt(BUFFER_GEOFENCE_EXITS, bufferGeofenceExits)
             putOpt(DEFAULT_GEOFENCE_DWELL_THRESHOLD, defaultGeofenceDwellThreshold)
             putOpt(MAX_REPLAY_BUFFER_SIZE, maxReplayBufferSize)
+            putOpt(OFFLINE_EVENT_GENERATION_ENABLED, offlineEventGenerationEnabled)
+            putOpt(USE_OFFLINE_RTO_UPDATES, useOfflineRTOUpdates)
+            putOpt(REMOTE_TRACKING_OPTIONS, RadarRemoteTrackingOptions.toJsonArray(remoteTrackingOptions))
         }
     }
 }

--- a/sdk/src/main/java/io/radar/sdk/model/RadarSdkConfiguration.kt
+++ b/sdk/src/main/java/io/radar/sdk/model/RadarSdkConfiguration.kt
@@ -93,7 +93,7 @@ internal data class RadarSdkConfiguration(
                 config.optBoolean(OFFLINE_EVENT_GENERATION_ENABLED, false),
                 config.optBoolean(USE_OFFLINE_RTO_UPDATES, false),
                 RadarRemoteTrackingOptions.fromJsonArray(config.optJSONArray(REMOTE_TRACKING_OPTIONS)),
-                )
+            )
         }
 
         fun updateSdkConfigurationFromServer(context: Context) {

--- a/sdk/src/test/java/io/radar/sdk/RadarOfflineEventManagerTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarOfflineEventManagerTest.kt
@@ -1,0 +1,370 @@
+package io.radar.sdk
+
+import android.content.Context
+import android.location.Location
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.radar.sdk.model.RadarCircleGeometry
+import io.radar.sdk.model.RadarCoordinate
+import io.radar.sdk.model.RadarGeofence
+import io.radar.sdk.model.RadarSdkConfiguration
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class RadarOfflineEventManagerTest {
+
+    companion object {
+        private const val TEST_LAT = 40.78382
+        private const val TEST_LNG = -73.97536
+        private const val TEST_LAT_FAR = 40.78562
+    }
+
+    private lateinit var context: Context
+    private lateinit var syncManager: RadarSyncManager
+    private lateinit var offlineEventManager: RadarOfflineEventManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        Radar.initialize(context, "prj_test_pk_0000000000000000000000000000000000000000")
+        ShadowLooper.idleMainLooper()
+        syncManager = RadarSyncManager(context, Radar.apiClient, Radar.logger)
+        syncManager.syncStore.clear()
+        offlineEventManager = RadarOfflineEventManager(context, syncManager, Radar.logger)
+        RadarSettings.setSdkConfiguration(context, null)
+        RadarState.setLastUser(context, null)
+    }
+
+    @After
+    fun tearDown() {
+        syncManager.syncStore.clear()
+        RadarSettings.setSdkConfiguration(context, null)
+        RadarState.setLastUser(context, null)
+        offlineEventManager.reset()
+        ShadowLooper.idleMainLooper()
+    }
+
+    // region Helpers
+
+    private fun makeLocation(lat: Double, lng: Double, accuracy: Float = 5f): Location {
+        val loc = Location("test")
+        loc.latitude = lat
+        loc.longitude = lng
+        loc.accuracy = accuracy
+        loc.time = System.currentTimeMillis()
+        return loc
+    }
+
+    private fun makeCircleGeofence(
+        id: String, lat: Double, lng: Double, radius: Double, tag: String = "test"
+    ): RadarGeofence {
+        return RadarGeofence(
+            id, "Test Geofence", tag, id, null, null,
+            RadarCircleGeometry(RadarCoordinate(lat, lng), radius),
+            null, null
+        )
+    }
+
+    private fun setState(state: RadarSyncState) {
+        syncManager.syncStore.write(state)
+    }
+
+    private fun makeRemoteTrackingOptionsJson(
+        type: String,
+        preset: String,
+        geofenceTags: List<String>? = null
+    ): JSONObject {
+        val trackingOptions = when (preset) {
+            "continuous" -> RadarTrackingOptions.CONTINUOUS
+            "responsive" -> RadarTrackingOptions.RESPONSIVE
+            else -> RadarTrackingOptions.EFFICIENT
+        }
+        return JSONObject().apply {
+            put("type", type)
+            put("trackingOptions", trackingOptions.toJson())
+            geofenceTags?.let { put("geofenceTags", JSONArray(it)) }
+        }
+    }
+
+    private fun makeSdkConfig(
+        offlineEventGenerationEnabled: Boolean = false,
+        useOfflineRTOUpdates: Boolean = false,
+        remoteTrackingOptions: List<JSONObject>? = null
+    ): RadarSdkConfiguration {
+        val json = JSONObject().apply {
+            put("offlineEventGenerationEnabled", offlineEventGenerationEnabled)
+            put("useOfflineRTOUpdates", useOfflineRTOUpdates)
+            if (remoteTrackingOptions != null) {
+                put("remoteTrackingOptions", JSONArray().apply {
+                    remoteTrackingOptions.forEach { put(it) }
+                })
+            }
+        }
+        return RadarSdkConfiguration.fromJson(json)
+    }
+
+    // endregion
+
+    // region handleTrackFailure gating
+
+    @Test
+    fun test_handleTrackFailure_doesNothing_whenDisabled() {
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(offlineEventGenerationEnabled = false))
+
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0)
+        setState(RadarSyncState(
+            syncedGeofences = listOf(geofence),
+            lastSyncedGeofenceIds = emptyList()
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+        offlineEventManager.handleTrackFailure(location)
+
+        // offlineGeofenceIds should still be empty — verify by calling generateEvents.
+        // If handleTrackFailure had run, offlineGeofenceIds would contain "geo1" and
+        // the next generateEvents call would detect no entry. Since it didn't run,
+        // baseline IDs (empty) are used, so "geo1" is detected as a fresh entry.
+        var eventCount = 0
+        offlineEventManager.generateEvents(location) { events, _, _ ->
+            eventCount = events.size
+        }
+        assertEquals(1, eventCount)
+    }
+
+    @Test
+    fun test_handleTrackFailure_runs_whenEnabled() {
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(offlineEventGenerationEnabled = true))
+
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0)
+        setState(RadarSyncState(
+            syncedGeofences = listOf(geofence),
+            lastSyncedGeofenceIds = emptyList()
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+        offlineEventManager.handleTrackFailure(location)
+
+        // offlineGeofenceIds now contains "geo1". Next generateEvents call detects no change.
+        var eventCount = -1
+        offlineEventManager.generateEvents(location) { events, _, _ ->
+            eventCount = events.size
+        }
+        assertEquals(0, eventCount)
+    }
+
+    // endregion
+
+    // region generateEvents
+
+    @Test
+    fun test_generateEvents_detectsEntry() {
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0)
+        setState(RadarSyncState(
+            syncedGeofences = listOf(geofence),
+            lastSyncedGeofenceIds = emptyList()
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+        var events = emptyList<io.radar.sdk.model.RadarEvent>()
+        offlineEventManager.generateEvents(location) { e, _, _ ->
+            events = e
+        }
+
+        assertEquals(1, events.size)
+        assertEquals(io.radar.sdk.model.RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, events[0].type)
+        assertEquals("geo1", events[0].geofence?._id)
+    }
+
+    @Test
+    fun test_generateEvents_detectsExit() {
+        val geofence = makeCircleGeofence("geo1", TEST_LAT_FAR, TEST_LNG, 50.0)
+        setState(RadarSyncState(
+            syncedGeofences = listOf(geofence),
+            lastSyncedGeofenceIds =  listOf("geo1")
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+        var events = emptyList<io.radar.sdk.model.RadarEvent>()
+        offlineEventManager.generateEvents(location) {e, _, _ ->
+            events = e
+        }
+        assertEquals(1, events.size)
+        assertEquals(io.radar.sdk.model.RadarEvent.RadarEventType.USER_EXITED_GEOFENCE, events[0].type)
+    }
+
+    @Test
+    fun test_generateEvents_noChange() {
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0)
+        setState(RadarSyncState(
+            syncedGeofences = listOf(geofence),
+            lastSyncedGeofenceIds = listOf("geo1")
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+        var events = listOf<io.radar.sdk.model.RadarEvent>(/* sentinel */)
+        offlineEventManager.generateEvents(location) { e, _, _ ->
+            events = e
+        }
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun test_generateEvents_eventMetadata() {
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0)
+        setState(RadarSyncState(
+            syncedGeofences = listOf(geofence),
+            lastSyncedGeofenceIds = emptyList()
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+        var events = emptyList<io.radar.sdk.model.RadarEvent>()
+        offlineEventManager.generateEvents(location) { e, _, _ ->
+            events = e
+        }
+        assertEquals(1, events.size)
+        val event = events[0]
+        assertFalse(event.replayed)
+        assertEquals(true, event.metadata?.optBoolean("offline"))
+    }
+
+    // endregion
+
+    // region reset
+
+    @Test
+    fun test_reset_clearsOfflineGeofenceIds() {
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0)
+        setState(RadarSyncState(
+            syncedGeofences = listOf(geofence),
+            lastSyncedGeofenceIds = emptyList()
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+
+        // 1st call: entry detected + offlineGeofenceIds populated with "geo1"
+        offlineEventManager.generateEvents(location) { _, _, _ -> }
+
+        // 2nd call: no change expected
+        var noChange = listOf<io.radar.sdk.model.RadarEvent>(/* sentinel */)
+        offlineEventManager.generateEvents(location) { e, _, _ -> noChange = e }
+        assertTrue(noChange.isEmpty())
+
+        // Reset — offlineGeofenceIds cleared; baseline IDs (still empty) used next call.
+        offlineEventManager.reset()
+
+        var postReset = emptyList<io.radar.sdk.model.RadarEvent>()
+        offlineEventManager.generateEvents(location) { e, _, _ -> postReset = e }
+        assertEquals(1, postReset.size)
+        assertEquals(io.radar.sdk.model.RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, postReset[0].type)
+    }
+
+    // endregion
+
+    // region updateTrackingOptions (by tags)
+
+    @Test
+    fun test_updateTrackingOptions_returnsInGeofence_whenTagsMatch() {
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(
+            useOfflineRTOUpdates = true,
+            remoteTrackingOptions = listOf(
+                makeRemoteTrackingOptionsJson("default", "responsive"),
+                makeRemoteTrackingOptionsJson("inGeofence", "continuous", listOf("neighborhood"))
+            )
+        ))
+
+        val result = offlineEventManager.updateTrackingOptions(listOf("neighborhood"))
+        assertNotNull(result)
+        assertEquals(RadarTrackingOptions.CONTINUOUS, result)
+    }
+
+    @Test
+    fun test_updateTrackingOptions_returnsDefault_whenTagsDoNotMatch() {
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(
+            useOfflineRTOUpdates = true,
+            remoteTrackingOptions = listOf(
+                makeRemoteTrackingOptionsJson("default", "responsive"),
+                makeRemoteTrackingOptionsJson("inGeofence", "continuous", listOf("neighborhood"))
+            )
+        ))
+
+        val result = offlineEventManager.updateTrackingOptions(listOf("some-other-tag"))
+        assertEquals(RadarTrackingOptions.RESPONSIVE, result)
+    }
+
+    @Test
+    fun test_updateTrackingOptions_returnsNull_whenNoRemoteOptions() {
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(useOfflineRTOUpdates = false))
+        val result = offlineEventManager.updateTrackingOptions(listOf("neighborhood"))
+        assertNull(result)
+    }
+
+    @Test
+    fun test_updateTrackingOptions_returnsDefault_whenTagsEmpty() {
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(
+            useOfflineRTOUpdates = true,
+            remoteTrackingOptions = listOf(
+                makeRemoteTrackingOptionsJson("default", "responsive"),
+                makeRemoteTrackingOptionsJson("inGeofence", "continuous", listOf("neighborhood"))
+            )
+        ))
+
+        val result = offlineEventManager.updateTrackingOptions(emptyList<String>())
+        assertEquals(RadarTrackingOptions.RESPONSIVE, result)
+    }
+
+    // endregion
+
+    // region updateTrackingOptions (by location)
+
+    @Test
+    fun test_updateTrackingOptions_byLocation_insideTaggedGeofence() {
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0, tag = "neighborhood")
+        setState(RadarSyncState(syncedGeofences = listOf(geofence)))
+
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(
+            useOfflineRTOUpdates = true,
+            remoteTrackingOptions = listOf(
+                makeRemoteTrackingOptionsJson("default", "responsive"),
+                makeRemoteTrackingOptionsJson("inGeofence", "continuous", listOf("neighborhood"))
+            )
+        ))
+
+        val location = makeLocation(TEST_LAT, TEST_LNG)
+        val result = offlineEventManager.updateTrackingOptions(location)
+        assertEquals(RadarTrackingOptions.CONTINUOUS, result)
+    }
+
+    @Test
+    fun test_updateTrackingOptions_byLocation_outsideGeofence_returnsDefault() {
+        val geofence = makeCircleGeofence("geo1", TEST_LAT, TEST_LNG, 100.0, tag = "neighborhood")
+        setState(RadarSyncState(syncedGeofences = listOf(geofence)))
+
+        RadarSettings.setSdkConfiguration(context, makeSdkConfig(
+            useOfflineRTOUpdates = true,
+            remoteTrackingOptions = listOf(
+                makeRemoteTrackingOptionsJson("default", "responsive"),
+                makeRemoteTrackingOptionsJson("inGeofence", "continuous", listOf("neighborhood"))
+            )
+        ))
+
+        val location = makeLocation(TEST_LAT_FAR, TEST_LNG)
+        val result = offlineEventManager.updateTrackingOptions(location)
+        assertEquals(RadarTrackingOptions.RESPONSIVE, result)
+    }
+
+    // endregion
+}

--- a/sdk/src/test/java/io/radar/sdk/model/RadarSdkConfigurationTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/model/RadarSdkConfigurationTest.kt
@@ -58,6 +58,8 @@ class RadarSdkConfigurationTest {
             "bufferGeofenceExits":true,
             "defaultGeofenceDwellThreshold":0,
             "maxReplayBufferSize":$maxReplayBufferSize,
+            "offlineEventGenerationEnabled":false,
+            "useOfflineRTOUpdates":false,
         }""".trimIndent()
     }
 
@@ -85,6 +87,9 @@ class RadarSdkConfigurationTest {
                 true,
                 0,
                 maxReplayBufferSize,
+                false,
+                false,
+                null
             ).toJson().toString()
         )
     }
@@ -106,6 +111,9 @@ class RadarSdkConfigurationTest {
         assertEquals(locationManagerTimeout, settings.locationManagerTimeout)
         assertEquals(syncAfterSetUser, settings.syncAfterSetUser)
         assertEquals(maxReplayBufferSize, settings.maxReplayBufferSize)
+        assertFalse(settings.offlineEventGenerationEnabled)
+        assertFalse(settings.useOfflineRTOUpdates)
+        assertEquals(null, settings.remoteTrackingOptions)
     }
 
     @Test
@@ -124,6 +132,9 @@ class RadarSdkConfigurationTest {
         assertFalse(settings.useForegroundLocationUpdatedAtMsDiff)
         assertEquals(0, settings.locationManagerTimeout)
         assertEquals(120, settings.maxReplayBufferSize)
+        assertFalse(settings.offlineEventGenerationEnabled)
+        assertFalse(settings.useOfflineRTOUpdates)
+        assertEquals(null, settings.remoteTrackingOptions)
     }
 
     private fun String.removeWhitespace(): String = replace("\\s".toRegex(), "")


### PR DESCRIPTION
## Summary

Introduces `RadarOfflineEventManager` — a client-side system for generating synthetic geofence events and switching tracking options when the device is offline. This is gated by two independent server-controlled flags: `offlineEventGenerationEnabled` (for synthetic events) and `useOfflineRTOUpdates` (for tracking option switching). Also adds `RadarRemoteTrackingOptions` to parse and look up the array of tagged tracking presets sent by the server.

## New SDK Components

**`RadarOfflineEventManager`** — Generates synthetic geofence entry/exit events by evaluating the device's location against locally cached geofence data from the sync region. On track failure, fires events via `Radar.sendEvents(...)` and optionally switches tracking options based on geofence tag matching. Builds a synthetic `RadarUser` using the cached user identity from `RadarState`. Thread-safe access to `offlineGeofenceIds` is guarded by a `synchronized(lock)` block.

**`RadarRemoteTrackingOptions`** — Parses the `remoteTrackingOptions` array from `sdkConfiguration`. Each entry has a `type` (`default`, `onTrip`, `inGeofence`), a `trackingOptions` preset, and optional `geofenceTags`. Provides lookup helpers (`trackingOptions(forKey, options)` and `geofenceTags(forKey, options)`) to retrieve tracking options or geofence tags by type.

## How It Works

1. **Server sends configuration**: `offlineEventGenerationEnabled` and `useOfflineRTOUpdates` arrive in `sdkConfiguration`. When `useOfflineRTOUpdates` is true, the server also sends a `remoteTrackingOptions` array with tagged presets. These are parsed by `RadarSdkConfiguration.fromJson` and `RadarRemoteTrackingOptions.fromJsonArray`.

2. **Track failure triggers offline logic** (`RadarApiClient.kt`): When a track call fails, the API client calls `Radar.offlineEventManager.handleTrackFailure(location)` (gated internally by `offlineEventGenerationEnabled`). If `useOfflineRTOUpdates` is true, it also calls `updateTrackingOptions(location)` and applies the returned `RadarTrackingOptions` via `locationManager.updateTrackingFromMeta(RadarMeta(offlineOptions, null))`, reusing the existing remote-tracking-options flow.

3. **Event generation** (`generateEvents`): Compares the current location against synced geofences from `RadarSyncManager` via the new pure `getGeofenceEntries(location, against)` and `getGeofenceExits(location, against)` helpers. Detects entries and exits relative to the previously known geofence set. Builds synthetic `RadarEvent` objects with `metadata: {offline: true}` and delivers them through the `Radar.sendEvents(events, user)` entry point.

4. **Synthetic user** (`buildSyntheticUser`): Retrieves the cached `RadarUser` from `RadarState.getLastUser(context)` (persisted on every successful track) and constructs a new user with updated location and geofences, while preserving identity fields (`_id`, `userId`, `deviceId`, `description`, `metadata`).

5. **Tracking option switching** (`updateTrackingOptions`): Checks if the user is in a geofence whose tag matches the `inGeofence` remote tracking option's `geofenceTags`. If matched, ramps up to in-geofence tracking options. Otherwise falls back to on-trip (if `Radar.getTripOptions() != null` and an `onTrip` preset is configured) or default tracking options.

6. **Sync region re-fetch** (`RadarLocationManager.kt`): When `offlineEventGenerationEnabled` is true, proactively re-fetches the sync region via `Radar.syncManager.fetchSyncRegion()` if the device moves outside or near the boundary of the current synced region (`isOutsideSyncedRegion` || `isNearSyncedRegionBoundary`), ensuring fresh geofence data for offline event evaluation.

7. **User caching** (`RadarState.kt`): Added `getLastUser(context)` / `setLastUser(context, user)` to persist the full `RadarUser` as a JSON string in `SharedPreferences` on every successful track response.

## Test Coverage

Unit tests in `RadarOfflineEventManagerTest.kt` (JUnit4 + Robolectric) covering:
- `handleTrackFailure` gating by `offlineEventGenerationEnabled` (both disabled and enabled)
- `generateEvents` entry detection, exit detection, no-change behavior, and event metadata (`offline: true`, `replayed: false`)
- `reset` clearing offline geofence state
- `updateTrackingOptions` by tags (match, no-match, empty tags, no remote options)
- `updateTrackingOptions` by location (inside and outside tagged geofences)