### PR TITLE
FENCE-2717: Add Batching

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -4004,6 +4004,19 @@ object Radar {
     }
 
     @JvmStatic
+    internal fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions) {
+        replayBuffer.addToBatch(batchParams, options)
+    }
+    @JvmStatic
+    internal fun shouldFlushBatch(options: RadarTrackingOptions): Boolean {
+        return replayBuffer.shouldFlushBatch(options)
+    }
+    @JvmStatic
+    internal fun flushBatch() {
+        replayBuffer.flushBatch()
+    }
+
+    @JvmStatic
     internal fun isTestKey(): Boolean {
         val key = RadarSettings.getPublishableKey(this.context)
         val userDebug = RadarSettings.getUserDebug(this.context)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -482,7 +482,14 @@ internal class RadarApiClient(
 
         val batchingEnabled = (options.batchSize > 0 || options.batchInterval > 0)
 
+        // Batching short-circuit: when batching is enabled and this track
+        // call came from a source that can tolerate deferred delivery,
+        // buffer the params instead of making the network call. We return
+        // SUCCESS immediately; the buffered items will be flushed later,
+        // either when batchSize is reached or when the batch timer fires.
         if (batchingEnabled &&
+            // Skip batching for user-initiated (MANUAL) and in-app (FOREGROUND)
+            // tracks, which need immediate network delivery and populated callbacks.
             source != RadarLocationSource.MANUAL_LOCATION &&
             source != RadarLocationSource.FOREGROUND_LOCATION) {
             val batchParams = JSONObject(params.toString())

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -475,6 +475,24 @@ internal class RadarApiClient(
         val path = "v1/track"
         val headers = headers(publishableKey)
 
+        val batchingEnabled = (options.batchSize > 0 || options.batchInterval > 0)
+
+        if (batchingEnabled &&
+            source != RadarLocationSource.MANUAL_LOCATION &&
+            source != RadarLocationSource.FOREGROUND_LOCATION) {
+            val batchParams = JSONObject(params.toString())
+
+            Radar.addToBatch(batchParams, options)
+
+            if (Radar.shouldFlushBatch(options)) {
+                logger.d("Flushing batch: size limit reached")
+                Radar.flushBatch()
+            }
+
+            callback?.onComplete(RadarStatus.SUCCESS)
+            return
+        }
+
         if (anonymous) {
             val usage = "track"
             this.getConfig(usage)

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -475,6 +475,11 @@ internal class RadarApiClient(
         val path = "v1/track"
         val headers = headers(publishableKey)
 
+        if (anonymous) {
+            val usage = "track"
+            this.getConfig(usage)
+        }
+
         val batchingEnabled = (options.batchSize > 0 || options.batchInterval > 0)
 
         if (batchingEnabled &&
@@ -489,13 +494,9 @@ internal class RadarApiClient(
                 Radar.flushBatch()
             }
 
+            RadarSettings.updateLastTrackedTime(context)
             callback?.onComplete(RadarStatus.SUCCESS)
             return
-        }
-
-        if (anonymous) {
-            val usage = "track"
-            this.getConfig(usage)
         }
 
         val hasReplays = Radar.hasReplays()

--- a/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarTrackingOptions.kt
@@ -125,6 +125,16 @@ data class RadarTrackingOptions(
     var usePressure: Boolean,
 
     /**
+     * Determines the time interval between batch events, in seconds. Set to 0 to disable interval-based batching.
+     */
+    var batchInterval: Int,
+
+    /**
+     * Determines the size of each batch. Set to 0 to disable size-based batching.
+     */
+    var batchSize: Int,
+
+    /**
      * Specifies the tracking options preset type used to configure this instance.
      */
     var type: RadarTrackingOptionsType = RadarTrackingOptionsType.DEFAULT,
@@ -475,7 +485,9 @@ data class RadarTrackingOptions(
             foregroundServiceEnabled = true,
             beacons = false,
             useMotion = false,
-            usePressure = false
+            usePressure = false,
+            batchInterval = 0,
+            batchSize = 0
         )
 
         /**
@@ -506,7 +518,9 @@ data class RadarTrackingOptions(
             foregroundServiceEnabled = false,
             beacons = false,
             useMotion = false,
-            usePressure = false
+            usePressure = false,
+            batchInterval = 0,
+            batchSize = 0
         )
 
         /**
@@ -537,7 +551,9 @@ data class RadarTrackingOptions(
             foregroundServiceEnabled = false,
             beacons = false,
             useMotion = false,
-            usePressure = false
+            usePressure = false,
+            batchInterval = 0,
+            batchSize = 0
         )
 
         internal const val KEY_DESIRED_STOPPED_UPDATE_INTERVAL = "desiredStoppedUpdateInterval"
@@ -562,6 +578,8 @@ data class RadarTrackingOptions(
         internal const val KEY_BEACONS = "beacons"
         internal const val KEY_USE_MOTION = "useMotion"
         internal const val KEY_USE_PRESSURE = "usePressure"
+        internal const val KEY_BATCH_INTERVAL = "batchInterval"
+        internal const val KEY_BATCH_SIZE = "batchSize"
         internal const val KEY_TYPE = "type"
         @JvmStatic
         fun fromJson(obj: JSONObject): RadarTrackingOptions {
@@ -640,6 +658,8 @@ data class RadarTrackingOptions(
                 beacons = obj.optBoolean(KEY_BEACONS),
                 useMotion = obj.optBoolean(KEY_USE_MOTION),
                 usePressure = obj.optBoolean(KEY_USE_PRESSURE),
+                batchInterval = obj.optInt(KEY_BATCH_INTERVAL),
+                batchSize = obj.optInt(KEY_BATCH_SIZE),
                 type = type
             )
         }
@@ -669,6 +689,8 @@ data class RadarTrackingOptions(
         obj.put(KEY_BEACONS, beacons)
         obj.put(KEY_USE_MOTION, useMotion)
         obj.put(KEY_USE_PRESSURE, usePressure)
+        obj.put(KEY_BATCH_INTERVAL, batchInterval)
+        obj.put(KEY_BATCH_SIZE, batchSize)
         obj.put(KEY_TYPE, type.toRadarString())
         return obj
     }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
@@ -1,5 +1,6 @@
 package io.radar.sdk.util
 
+import io.radar.sdk.RadarTrackingOptions
 import io.radar.sdk.model.RadarReplay
 import org.json.JSONObject
 
@@ -12,4 +13,11 @@ internal interface RadarReplayBuffer {
     fun getFlushableReplaysStash(): Flushable<RadarReplay>
 
     fun loadFromSharedPreferences()
+
+    fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions)
+    fun shouldFlushBatch(options: RadarTrackingOptions): Boolean
+    fun scheduleBatchTimer(interval: Int)
+    fun cancelBatchTimer()
+    fun flushBatch()
+    fun batchCount(): Int
 }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarReplayBuffer.kt
@@ -20,4 +20,5 @@ internal interface RadarReplayBuffer {
     fun cancelBatchTimer()
     fun flushBatch()
     fun batchCount(): Int
+    fun shutdown()
 }

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
@@ -169,7 +169,9 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
     override fun flushBatch() {
         if (Radar.isFlushingReplays) {
             Radar.logger.d("Skipping batch flush; already flushing replays")
-            return  // keep the timer alive so we retry later
+            // another flush is in progress; bail without canceling the timer
+            // so the next size-check or timer fire gets a chance
+            return
         }
         cancelBatchTimer()
         Radar.flushReplays()

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
@@ -13,7 +13,6 @@ import io.radar.sdk.Radar
 import io.radar.sdk.RadarTrackingOptions
 import android.os.Handler
 import android.os.HandlerThread
-import java.util.Date
 
 internal class RadarSimpleReplayBuffer(private val context: Context) : RadarReplayBuffer {
 
@@ -24,10 +23,9 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
     }
 
     private val buffer = LinkedBlockingDeque<RadarReplay>(MAXIMUM_CAPACITY)
-    private val batchHandlerThread = HandlerThread("RadarBatchTimer").apply { start() }
-    private val batchHandler = Handler(batchHandlerThread.looper)
+    private var batchHandlerThread: HandlerThread? = null
+    private var batchHandler: Handler? = null
     private var batchTimerRunnable: Runnable? = null
-    private var batchStartTime: Date? = null
 
     override fun getSize(): Int {
         return buffer.size
@@ -98,6 +96,16 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
 
     // region Batch methods
 
+    private fun ensureBatchHandler(): Handler {
+        return synchronized(this) {
+            batchHandler ?: run {
+                val thread = HandlerThread("RadarBatchTimer").apply { start() }
+                batchHandlerThread = thread
+                Handler(thread.looper).also { batchHandler = it }
+            }
+        }
+    }
+
     override fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions) {
         val params = JSONObject(batchParams.toString())
         params.put("replayed", true)
@@ -107,10 +115,6 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
         write(params)
 
         synchronized(this) {
-            if (batchStartTime == null) {
-                batchStartTime = Date()
-            }
-
             if (options.batchInterval > 0 && batchTimerRunnable == null) {
                 scheduleBatchTimer(options.batchInterval)
             }
@@ -136,16 +140,19 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
         if (interval <= 0) return
 
         synchronized(this) {
-            batchTimerRunnable?.let { batchHandler.removeCallbacks(it) }
+            val handler = ensureBatchHandler()
+            batchTimerRunnable?.let { handler.removeCallbacks(it) }
 
             Radar.logger.d("Scheduling batch timer | interval = $interval")
 
             val runnable = Runnable {
                 Radar.logger.d("Batch timer fired")
+                synchronized(this) { batchTimerRunnable = null }
                 flushBatch()
             }
+
             batchTimerRunnable = runnable
-            batchHandler.postDelayed(runnable, interval * 1000L)
+            handler.postDelayed(runnable, interval * 1000L)
         }
     }
 
@@ -153,22 +160,32 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
         synchronized(this) {
             batchTimerRunnable?.let { runnable ->
                 Radar.logger.d("Canceling batch timer")
-                batchHandler.removeCallbacks(runnable)
+                batchHandler?.removeCallbacks(runnable)
                 batchTimerRunnable = null
             }
         }
     }
 
     override fun flushBatch() {
-        cancelBatchTimer()
-        synchronized(this) {
-            batchStartTime = null
+        if (Radar.isFlushingReplays) {
+            Radar.logger.d("Skipping batch flush; already flushing replays")
+            return  // keep the timer alive so we retry later
         }
+        cancelBatchTimer()
         Radar.flushReplays()
     }
 
     override fun batchCount(): Int {
         return buffer.size
+    }
+
+    override fun shutdown() {
+        cancelBatchTimer()
+        synchronized(this) {
+            batchHandlerThread?.quit()
+            batchHandlerThread = null
+            batchHandler = null
+        }
     }
 
     // endregion

--- a/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
+++ b/sdk/src/main/java/io/radar/sdk/util/RadarSimpleReplayBuffer.kt
@@ -9,6 +9,11 @@ import androidx.core.content.edit
 import java.util.concurrent.LinkedBlockingDeque
 import org.json.JSONObject
 import org.json.JSONArray
+import io.radar.sdk.Radar
+import io.radar.sdk.RadarTrackingOptions
+import android.os.Handler
+import android.os.HandlerThread
+import java.util.Date
 
 internal class RadarSimpleReplayBuffer(private val context: Context) : RadarReplayBuffer {
 
@@ -19,6 +24,10 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
     }
 
     private val buffer = LinkedBlockingDeque<RadarReplay>(MAXIMUM_CAPACITY)
+    private val batchHandlerThread = HandlerThread("RadarBatchTimer").apply { start() }
+    private val batchHandler = Handler(batchHandlerThread.looper)
+    private var batchTimerRunnable: Runnable? = null
+    private var batchStartTime: Date? = null
 
     override fun getSize(): Int {
         return buffer.size
@@ -86,4 +95,81 @@ internal class RadarSimpleReplayBuffer(private val context: Context) : RadarRepl
     private fun getSharedPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
     }
+
+    // region Batch methods
+
+    override fun addToBatch(batchParams: JSONObject, options: RadarTrackingOptions) {
+        val params = JSONObject(batchParams.toString())
+        params.put("replayed", true)
+        params.put("updatedAtMs", System.currentTimeMillis())
+        params.remove("updatedAtMsDiff")
+
+        write(params)
+
+        synchronized(this) {
+            if (batchStartTime == null) {
+                batchStartTime = Date()
+            }
+
+            if (options.batchInterval > 0 && batchTimerRunnable == null) {
+                scheduleBatchTimer(options.batchInterval)
+            }
+        }
+
+        Radar.logger.d("Added to batch | size = ${buffer.size}")
+    }
+
+    override fun shouldFlushBatch(options: RadarTrackingOptions): Boolean {
+        if (buffer.size == 0) {
+            return false
+        }
+
+        if (options.batchSize > 0 && buffer.size >= options.batchSize) {
+            Radar.logger.d("Batch size limit reached")
+            return true
+        }
+
+        return false
+    }
+
+    override fun scheduleBatchTimer(interval: Int) {
+        if (interval <= 0) return
+
+        synchronized(this) {
+            batchTimerRunnable?.let { batchHandler.removeCallbacks(it) }
+
+            Radar.logger.d("Scheduling batch timer | interval = $interval")
+
+            val runnable = Runnable {
+                Radar.logger.d("Batch timer fired")
+                flushBatch()
+            }
+            batchTimerRunnable = runnable
+            batchHandler.postDelayed(runnable, interval * 1000L)
+        }
+    }
+
+    override fun cancelBatchTimer() {
+        synchronized(this) {
+            batchTimerRunnable?.let { runnable ->
+                Radar.logger.d("Canceling batch timer")
+                batchHandler.removeCallbacks(runnable)
+                batchTimerRunnable = null
+            }
+        }
+    }
+
+    override fun flushBatch() {
+        cancelBatchTimer()
+        synchronized(this) {
+            batchStartTime = null
+        }
+        Radar.flushReplays()
+    }
+
+    override fun batchCount(): Int {
+        return buffer.size
+    }
+
+    // endregion
 }

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -304,6 +304,7 @@ class RadarTest {
         
         // Clear captured parameters from previous tests
         apiHelperMock.clearCapturedParams()
+        Radar.flushBatch()
     }
 
     @Test
@@ -1151,6 +1152,18 @@ class RadarTest {
     }
 
     @Test
+    fun test_RadarTrackingOptions_presetDefaults_haveZeroBatching() {
+        for (preset in listOf(
+            RadarTrackingOptions.CONTINUOUS,
+            RadarTrackingOptions.RESPONSIVE,
+            RadarTrackingOptions.EFFICIENT
+        )) {
+            assertEquals(0, preset.batchInterval)
+            assertEquals(0, preset.batchSize)
+        }
+    }
+
+    @Test
     fun test_Radar_startTracking_continuous() {
         permissionsHelperMock.mockFineLocationPermissionGranted = true
 
@@ -1254,6 +1267,22 @@ class RadarTest {
         assertEquals(newOptions, Radar.getTrackingOptions())
         assertEquals(newOptions, options)
         assertTrue(Radar.isTracking())
+    }
+
+    @Test
+    fun test_RadarTrackingOptions_batching_serializeRoundTrip() {
+        val options = RadarTrackingOptions.RESPONSIVE
+        options.batchInterval = 30
+        options.batchSize = 5
+
+        val json = options.toJson()
+        assertEquals(30, json.getInt("batchInterval"))
+        assertEquals(5, json.getInt("batchSize"))
+
+        val decoded = RadarTrackingOptions.fromJson(json)
+        assertEquals(30, decoded.batchInterval)
+        assertEquals(5, decoded.batchSize)
+        assertEquals(options, decoded)
     }
 
     @Test

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -1271,9 +1271,10 @@ class RadarTest {
 
     @Test
     fun test_RadarTrackingOptions_batching_serializeRoundTrip() {
-        val options = RadarTrackingOptions.RESPONSIVE
-        options.batchInterval = 30
-        options.batchSize = 5
+        val options = RadarTrackingOptions.RESPONSIVE.copy(
+            batchInterval = 30,
+            batchSize = 5
+        )
 
         val json = options.toJson()
         assertEquals(30, json.getInt("batchInterval"))

--- a/sdk/src/test/java/io/radar/sdk/util/RadarSimpleReplayBufferTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/RadarSimpleReplayBufferTest.kt
@@ -33,10 +33,10 @@ class RadarSimpleReplayBufferTest {
     }
 
     private fun options(batchSize: Int, batchInterval: Int): RadarTrackingOptions {
-        val options = RadarTrackingOptions.RESPONSIVE
-        options.batchSize = batchSize
-        options.batchInterval = batchInterval
-        return options
+        return RadarTrackingOptions.RESPONSIVE.copy(
+            batchSize = batchSize,
+            batchInterval = batchInterval
+        )
     }
 
     @Test

--- a/sdk/src/test/java/io/radar/sdk/util/RadarSimpleReplayBufferTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/RadarSimpleReplayBufferTest.kt
@@ -29,7 +29,7 @@ class RadarSimpleReplayBufferTest {
 
     @After
     fun tearDown() {
-        buffer.cancelBatchTimer()
+        buffer.shutdown()
     }
 
     private fun options(batchSize: Int, batchInterval: Int): RadarTrackingOptions {

--- a/sdk/src/test/java/io/radar/sdk/util/RadarSimpleReplayBufferTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/util/RadarSimpleReplayBufferTest.kt
@@ -1,0 +1,80 @@
+package io.radar.sdk.util
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.radar.sdk.RadarTrackingOptions
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class RadarSimpleReplayBufferTest {
+
+    private lateinit var buffer: RadarSimpleReplayBuffer
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        buffer = RadarSimpleReplayBuffer(context)
+    }
+
+    @After
+    fun tearDown() {
+        buffer.cancelBatchTimer()
+    }
+
+    private fun options(batchSize: Int, batchInterval: Int): RadarTrackingOptions {
+        val options = RadarTrackingOptions.RESPONSIVE
+        options.batchSize = batchSize
+        options.batchInterval = batchInterval
+        return options
+    }
+
+    @Test
+    fun test_addToBatch_incrementsCount() {
+        val options = options(batchSize = 5, batchInterval = 0)
+        assertEquals(0, buffer.batchCount())
+        buffer.addToBatch(JSONObject().put("foo", "bar"), options)
+        assertEquals(1, buffer.batchCount())
+    }
+
+    @Test
+    fun test_shouldFlushBatch_byBatchSize() {
+        val options = options(batchSize = 2, batchInterval = 0)
+        buffer.addToBatch(JSONObject(), options)
+        assertFalse(buffer.shouldFlushBatch(options))
+        buffer.addToBatch(JSONObject(), options)
+        assertTrue(buffer.shouldFlushBatch(options))
+    }
+
+    @Test
+    fun test_shouldFlushBatch_withZeroBatchSize_neverFlushes() {
+        val options = options(batchSize = 0, batchInterval = 0)
+        repeat(10) { buffer.addToBatch(JSONObject(), options) }
+        assertFalse(buffer.shouldFlushBatch(options))
+    }
+
+    @Test
+    fun test_addToBatch_scheduleTimerAfterIntervalSetLate() {
+        // First adds with no interval -> no timer scheduled (mirrors reviewer fix #1 on iOS)
+        val noInterval = options(batchSize = 0, batchInterval = 0)
+        buffer.addToBatch(JSONObject(), noInterval)
+
+        // Later add with interval -> timer should still schedule since it's gated on
+        // `batchTimerRunnable == null`, not on "buffer was empty"
+        val withInterval = options(batchSize = 0, batchInterval = 30)
+        buffer.addToBatch(JSONObject(), withInterval)
+
+        // cancelBatchTimer should be safe to call synchronously without racing the scheduled runnable
+        buffer.cancelBatchTimer()
+    }
+}


### PR DESCRIPTION
## Summary

Adds server-controlled batching for non-foreground track requests to reduce network usage for customers who can tolerate deferred location sync. 

## Changes

- **`RadarTrackingOptions.kt`**
  - Adds `batchInterval` and `batchSize` properties (default `0` on `CONTINUOUS`, `RESPONSIVE`, and `EFFICIENT` presets).
  - Adds `KEY_BATCH_INTERVAL` / `KEY_BATCH_SIZE` and wires them into `toJson` / `fromJson`.

- **`RadarReplayBuffer.kt` / `RadarSimpleReplayBuffer.kt`**
  - Adds `addToBatch`, `shouldFlushBatch`, `scheduleBatchTimer`, `cancelBatchTimer`, `flushBatch`, and `batchCount` to the interface and implementation.
  - Implements timer-based flushing on a dedicated `HandlerThread` / `Handler`, with `synchronized(this)` around all timer/state mutations to avoid race conditions.
  - `addToBatch` always writes to the buffer, sets `batchStartTime` if `null`, and schedules a timer if `batchInterval > 0` and one isn't already scheduled.
  - `shouldFlushBatch` returns `true` when `batchSize > 0` and `buffer.size >= batchSize`.
  - `scheduleBatchTimer` invalidates any existing timer before scheduling a new one.
  - `cancelBatchTimer` synchronously removes the pending runnable.
  - `flushBatch` cancels the timer, resets `batchStartTime`, and triggers `Radar.flushReplays()`.

- **`RadarApiClient.kt`**
  - Short-circuits the `track(...)` flow when batching is enabled (`batchSize > 0` or `batchInterval > 0`) and the location source is not `MANUAL_LOCATION` or `FOREGROUND_LOCATION`. Adds the request to the batch buffer, flushes if the size threshold is hit, and returns `RadarStatus.SUCCESS`.

- **`Radar.kt`**
  - Adds internal `@JvmStatic` passthroughs for `addToBatch`, `shouldFlushBatch`, and `flushBatch` that delegate to `replayBuffer`.

## Tests

- **`RadarTest.kt`**
  - `test_RadarTrackingOptions_presetDefaults_haveZeroBatching` — confirms presets default `batchInterval` / `batchSize` to `0`.
  - `test_RadarTrackingOptions_batching_serializeRoundTrip` — verifies JSON round-trip of batching options.
  - Adds `Radar.flushBatch()` to `setUp` for test isolation.

- **`RadarSimpleReplayBufferTest.kt`** (new)
  - `test_addToBatch_incrementsCount`
  - `test_shouldFlushBatch_byBatchSize`
  - `test_shouldFlushBatch_withZeroBatchSize_neverFlushes`
  - `test_addToBatch_scheduleTimerAfterIntervalSetLate`