### PR TITLE
FENCE-2795: add ability to configure network timeout

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -687,7 +687,7 @@ object Radar {
 
         options.networkTimeout?.let { desiredTimeout ->
             if (!desiredTimeout.isFinite() || desiredTimeout.isNegative()) {
-                this.logger.d("networkTimeout ignored: must be finite and non-negative | value = $requested")
+                this.logger.d("networkTimeout ignored: must be finite and non-negative | value = $desiredTimeout")
                 return@let
             }
             val ms = desiredTimeout.inWholeMilliseconds

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -36,6 +36,7 @@ import io.radar.sdk.util.RadarSimpleReplayBuffer
 import org.json.JSONObject
 import java.util.Date
 import java.util.EnumSet
+import kotlin.time.Duration
 
 /**
  * The main class used to interact with the Radar SDK.
@@ -320,7 +321,7 @@ object Radar {
         ERROR_LOCATION,
         /** Beacon ranging error or timeout (5 seconds) */
         ERROR_BLUETOOTH,
-        /** Network error or timeout (10 seconds) */
+        /** Network error or timeout (10 seconds by default, configurable via [RadarOptions.networkTimeout]) */
         ERROR_NETWORK,
         /** Bad request (missing or invalid params) */
         ERROR_BAD_REQUEST,
@@ -536,10 +537,10 @@ object Radar {
      */
     @JvmStatic
     fun initialize(
-        context: Context?, 
-        publishableKey: String? = null, 
-        receiver: RadarReceiver? = null, 
-        provider: RadarLocationServicesProvider = RadarLocationServicesProvider.GOOGLE, 
+        context: Context?,
+        publishableKey: String? = null,
+        receiver: RadarReceiver? = null,
+        provider: RadarLocationServicesProvider = RadarLocationServicesProvider.GOOGLE,
         fraud: Boolean = false,
         customForegroundNotification: Notification? = null,
         inAppMessageReceiver: RadarInAppMessageReceiver? = null,
@@ -683,7 +684,20 @@ object Radar {
         val application = this.context as? Application
 
         RadarSettings.setFraudEnabled(this.context, options.fraud)
-        
+
+        options.networkTimeout?.let { desiredTimeout ->
+            if (!desiredTimeout.isFinite() || desiredTimeout.isNegative()) {
+                this.logger.d("networkTimeout ignored: must be finite and non-negative | value = $requested")
+                return@let
+            }
+            val ms = desiredTimeout.inWholeMilliseconds
+            val clamped = ms.coerceIn(1_000L, 300_000L).toInt()
+            if (clamped.toLong() != ms) {
+                this.logger.d("networkTimeout coerced to valid range | requested=${ms}ms; using=${clamped}ms")
+            }
+            RadarSettings.setNetworkTimeoutMs(this.context, clamped)
+        }
+
         if (options.fraud) {
             RadarSettings.setSharing(this.context, false)
         }
@@ -694,7 +708,7 @@ object Radar {
 
         activityLifecycleCallbacks = RadarActivityLifecycleCallbacks(options.fraud)
         application?.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
-        
+
         val sdkConfiguration = RadarSettings.getSdkConfiguration(this.context)
         if (sdkConfiguration.usePersistence) {
             loadReplayBufferFromSharedPreferences()
@@ -929,7 +943,7 @@ object Radar {
             return
         }
 
-        RadarSettings.setTags(context, tags) 
+        RadarSettings.setTags(context, tags)
     }
 
     /**
@@ -1569,7 +1583,7 @@ object Radar {
             return
         }
         this.logger.i("startTracking()", RadarLogType.SDK_CALL)
-        
+
         locationManager.startTracking(options)
     }
 
@@ -1742,7 +1756,7 @@ object Radar {
     }
 
 
-   /** 
+   /**
     *  Returns a string of the radar host.
     *
     *  @return A string of the radar host.
@@ -1817,7 +1831,7 @@ object Radar {
     /**
      * Sets a custom notification for the foreground service.
      * This notification will be used instead of the default SDK notification.
-     * 
+     *
      * @param[notification] The custom notification to use, or null to use the default
      */
     @JvmStatic
@@ -1879,7 +1893,7 @@ object Radar {
         }
 
         inAppMessageManager.setInAppMessageReceiver(inAppMessageReceiver)
-    }   
+    }
 
     /**
      * Accepts an event. Events can be accepted after user check-ins or other forms of verification. Event verifications will be used to improve the accuracy and confidence level of future events.
@@ -2523,7 +2537,7 @@ object Radar {
      * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
-     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries) 
+     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries)
      * @param[limit] The max number of places to return. A number between 1 and 100.
      * @param[block] A block callback.
      */
@@ -2563,7 +2577,7 @@ object Radar {
      * @param[chains] An array of chain slugs to filter. See [](https://radar.com/documentation/places/chains)
      * @param[categories] An array of categories to filter. See [](https://radar.com/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.com/documentation/places/groups)
-     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries) 
+     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries)
      * @param[limit] The max number of places to return. A number between 1 and 100.
      * @param[callback] A callback.
      */
@@ -2635,7 +2649,7 @@ object Radar {
      * @param[chains] An array of chain slugs to filter. See [](https://radar.com/documentation/places/chains)
      * @param[categories] An array of categories to filter. See [](https://radar.com/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.com/documentation/places/groups)
-     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries) 
+     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries)
      * @param[limit] The max number of places to return. A number between 1 and 100.
      * @param[block] A block callback.
      */
@@ -2664,7 +2678,7 @@ object Radar {
      * @param[chainMetadata] A map of metadata keys and values. Values can be strings, numerics, or booleans.
      * @param[categories] An array of categories to filter. See [](https://radar.io/documentation/places/categories)
      * @param[groups] An array of groups to filter. See [](https://radar.io/documentation/places/groups)
-     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries)     
+     * @param[countryCodes] An array of country codes to filter. See [](https://radar.com/documentation/regions/countries)
      * @param[limit] The max number of places to return. A number between 1 and 100.
      * @param[block] A block callback.
      */
@@ -3074,12 +3088,12 @@ object Radar {
 
     /**
      * Validates an address, attaching to a verification status, property type, and plus4.
-     * 
+     *
      * @see [](https://radar.com/documentation/api#validate-an-address)
-     * 
+     *
      * @param[address] The address to validate.
      * @param[callback] A callback.
-     * 
+     *
      */
 
     @JvmStatic
@@ -3110,12 +3124,12 @@ object Radar {
 
     /**
      * Validates an address, attaching to a verification status, property type, and plus4.
-     * 
+     *
      * @see [](https://radar.com/documentation/api#validate-an-address)
-     * 
+     *
      * @param[address] The address to validate.
      * @param[block] A block callback.
-     * 
+     *
      */
 
     fun validateAddress(
@@ -3293,7 +3307,7 @@ object Radar {
      * @see [](https://radar.com/documentation/api#reverse-geocode)
      *
      * @param[location] The location to geocode.
-     * @param[layers] Optional 
+     * @param[layers] Optional
      * @param[block] A block callback.
      */
     fun reverseGeocode(
@@ -3843,7 +3857,7 @@ object Radar {
                 override fun onComplete(status: RadarStatus, event: RadarEvent?) {
                     logger.i("Conversion name = ${event?.conversionName}: status = $status; event = $event")
                 }
-            }) 
+            })
         }
     }
 
@@ -3951,7 +3965,7 @@ object Radar {
             this.logger.d("No replays to flush")
             return
         }
-    
+
         this.isFlushingReplays = true
 
         // get a copy of the replays so we can safely clear what was synced up
@@ -4073,7 +4087,7 @@ object Radar {
             else -> "car"
         }
     }
-   
+
     /**
      * Returns a display string for a verification status value.
      *

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -321,7 +321,7 @@ object Radar {
         ERROR_LOCATION,
         /** Beacon ranging error or timeout (5 seconds) */
         ERROR_BLUETOOTH,
-        /** Network error or timeout (10 seconds by default, configurable via [RadarOptions.networkTimeout]) */
+        /** Network error or timeout (10 seconds by default, configurable via [RadarInitializeOptions.networkTimeout]) */
         ERROR_NETWORK,
         /** Bad request (missing or invalid params) */
         ERROR_BAD_REQUEST,

--- a/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiHelper.kt
@@ -103,11 +103,13 @@ internal open class RadarApiHelper(
                     }
                 }
                 urlConnection.requestMethod = method
-                urlConnection.connectTimeout = 10000
-                if (extendedTimeout) {
-                    urlConnection.readTimeout = 25000
+                val timeoutMs = RadarSettings.getNetworkTimeoutMs(context)
+                urlConnection.connectTimeout = timeoutMs
+                // Preserve historical 2.5x read timeout for long-running requests (was 25s vs 10s)
+                urlConnection.readTimeout = if (extendedTimeout) {
+                    (timeoutMs * 2.5).toInt()
                 } else {
-                    urlConnection.readTimeout = 10000
+                    timeoutMs
                 }
                 if (stream) {
                     urlConnection.setChunkedStreamingMode(1024)

--- a/sdk/src/main/java/io/radar/sdk/RadarInitializeOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarInitializeOptions.kt
@@ -2,6 +2,7 @@ package io.radar.sdk
 
 import android.app.Notification
 import android.app.Activity
+import kotlin.time.Duration
 
 /**
  * Initialize options for Radar
@@ -15,6 +16,8 @@ import android.app.Activity
  * @param[publishableKey] The project publishable key, if set, authToken should not be set.
  * @param[authToken] A JWT auth token, if set, publishableKey should not be set.
  * @param[activity] An optional activity that overwrites the activity from context.
+ * @param[networkTimeout] Connect and base read timeout for Radar API requests (e.g. `10.seconds` from `kotlin.time`).
+ * If set, the value is persisted. If null, a previously saved value or the default (10 seconds) is used.
  *
  */
 data class RadarInitializeOptions(
@@ -27,6 +30,7 @@ data class RadarInitializeOptions(
     val publishableKey: String? = null,
     val authToken: String? = null,
     val activity: Activity? = null,
+    val networkTimeout: Duration? = null,
 ) {
     class Builder {
         private var radarReceiver: RadarReceiver? = null
@@ -38,6 +42,7 @@ data class RadarInitializeOptions(
         private var publishableKey: String? = null
         private var authToken: String? = null
         private var activity: Activity? = null
+        private var networkTimeout: Duration? = null
 
         fun radarReceiver(radarReceiver: RadarReceiver) = apply { this.radarReceiver = radarReceiver }
         fun locationProvider(locationProvider: Radar.RadarLocationServicesProvider) = apply { this.locationProvider = locationProvider }
@@ -48,6 +53,7 @@ data class RadarInitializeOptions(
         fun publishableKey(publishableKey: String) = apply { this.publishableKey = publishableKey }
         fun authToken(authToken: String) = apply { this.authToken = authToken }
         fun activity(activity: Activity) = apply { this.activity = activity }
+        fun networkTimeout(networkTimeout: Duration) = apply { this.networkTimeout = networkTimeout }
 
         fun build() = RadarInitializeOptions(
             radarReceiver = radarReceiver,
@@ -59,6 +65,7 @@ data class RadarInitializeOptions(
             publishableKey = publishableKey,
             authToken = authToken,
             activity = activity,
+            networkTimeout = networkTimeout,
         )
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarInitializeOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarInitializeOptions.kt
@@ -16,8 +16,8 @@ import kotlin.time.Duration
  * @param[publishableKey] The project publishable key, if set, authToken should not be set.
  * @param[authToken] A JWT auth token, if set, publishableKey should not be set.
  * @param[activity] An optional activity that overwrites the activity from context.
- * @param[networkTimeout] Connect and base read timeout for Radar API requests (e.g. `10.seconds` from `kotlin.time`).
- * If set, the value is persisted. If null, a previously saved value or the default (10 seconds) is used.
+ * @param[networkTimeout] Connect and base read timeout for Radar API requests.
+ *                        If set, the value is persisted. If null, a previously saved value or default (10 seconds) is used.
  *
  */
 data class RadarInitializeOptions(

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -43,6 +43,9 @@ internal object RadarSettings {
     private const val KEY_X_PLATFORM_SDK_VERSION = "x_platform_sdk_version"
     private const val KEY_USER_TAGS = "user_tags"
     private const val KEY_FRAUD_ENABLED = "fraudEnabled"
+    private const val KEY_NETWORK_TIMEOUT_MS = "network_timeout_ms"
+
+    private const val DEFAULT_NETWORK_TIMEOUT_MS = 10000
 
     private const val KEY_OLD_UPDATE_INTERVAL = "dwell_delay"
     private const val KEY_OLD_UPDATE_INTERVAL_RESPONSIVE = 60000
@@ -171,6 +174,14 @@ internal object RadarSettings {
 
     internal fun setFraudEnabled(context: Context, enabled: Boolean) {
         getSharedPreferences(context).edit { putBoolean(KEY_FRAUD_ENABLED, enabled) }
+    }
+
+    internal fun getNetworkTimeoutMs(context: Context): Int {
+        return getSharedPreferences(context).getInt(KEY_NETWORK_TIMEOUT_MS, DEFAULT_NETWORK_TIMEOUT_MS)
+    }
+
+    internal fun setNetworkTimeoutMs(context: Context, timeoutMs: Int) {
+        getSharedPreferences(context).edit { putInt(KEY_NETWORK_TIMEOUT_MS, timeoutMs) }
     }
 
     internal fun getTracking(context: Context): Boolean {


### PR DESCRIPTION
- Adds a new initialization option, `networkTimeout`, that allows consumers to override the default 10 second timeout.
- Sets the extended timeout to 2.5x the network timeout instead of hardcoding 25 seconds.