### PR TITLE
Fix verified token handling after failover

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -618,11 +618,51 @@ internal class RadarApiClient(
                         RadarState.setBeaconIds(context, beaconIds)
                     }
 
-                    if (events != null && user != null) {
-                        RadarSettings.setId(context, user._id)
+                    val successUser = if (verified) token?.user ?: user else user
+                    val successEvents = if (verified) token?.events ?: events else events
 
-                        if (user.trip != null) {
-                            RadarSettings.setTrip(context, user.trip)
+                    if (verified && token != null) {
+                        successUser?.let { verifiedUser ->
+                            RadarSettings.setId(context, verifiedUser._id)
+
+                            if (verifiedUser.trip != null) {
+                                RadarSettings.setTrip(context, verifiedUser.trip)
+                            } else {
+                                RadarSettings.setTrip(context, null)
+                                val tripOptions = RadarSettings.getTripOptions(context)
+                                if (tripOptions != null) {
+                                    locationManager.restartPreviousTrackingOptions()
+                                    RadarSettings.setTripOptions(context, null)
+                                }
+                            }
+
+                            RadarSettings.setUserDebug(context, verifiedUser.debug)
+                            Radar.sendLocation(location, verifiedUser)
+                        }
+
+                        if (!successEvents.isNullOrEmpty()) {
+                            Radar.sendEvents(successEvents, successUser)
+                        }
+
+                        Radar.sendToken(token)
+
+                        val inAppMessages = res.optJSONArray("inAppMessages")?.let { inAppMessageObj ->
+                            RadarInAppMessage.fromJsonArray(inAppMessageObj)
+                        }
+                        if (inAppMessages != null) {
+                            Radar.showInAppMessages(inAppMessages)
+                        }
+
+                        callback?.onComplete(RadarStatus.SUCCESS, res, successEvents, successUser, nearbyGeofences, config, token)
+
+                        return
+                    }
+
+                    if (!verified && successEvents != null && successUser != null) {
+                        RadarSettings.setId(context, successUser._id)
+
+                        if (successUser.trip != null) {
+                            RadarSettings.setTrip(context, successUser.trip)
                         } else {
                             RadarSettings.setTrip(context, null)
                             val tripOptions = RadarSettings.getTripOptions(context)
@@ -632,16 +672,12 @@ internal class RadarApiClient(
                             }
                         }
 
-                        RadarSettings.setUserDebug(context, user.debug)
+                        RadarSettings.setUserDebug(context, successUser.debug)
 
-                        Radar.sendLocation(location, user)
+                        Radar.sendLocation(location, successUser)
 
-                        if (events.isNotEmpty()) {
-                            Radar.sendEvents(events, user)
-                        }
-
-                        if (token != null) {
-                            Radar.sendToken(token)
+                        if (successEvents.isNotEmpty()) {
+                            Radar.sendEvents(successEvents, successUser)
                         }
 
                         val inAppMessages = res.optJSONArray("inAppMessages")?.let { inAppMessageObj ->
@@ -651,7 +687,7 @@ internal class RadarApiClient(
                             Radar.showInAppMessages(inAppMessages)
                         }
 
-                        callback?.onComplete(RadarStatus.SUCCESS, res, events, user, nearbyGeofences, config, token)
+                        callback?.onComplete(RadarStatus.SUCCESS, res, successEvents, successUser, nearbyGeofences, config, token)
 
                         return
                     }

--- a/sdk/src/test/java/io/radar/sdk/RadarVerifiedHostOverrideTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarVerifiedHostOverrideTest.kt
@@ -5,9 +5,11 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONObject
+import org.json.JSONArray
 import android.location.Location
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -22,6 +24,28 @@ class RadarVerifiedHostOverrideTest {
     private val publishableKey = "prj_test_pk_0000000000000000000000000000000000000000"
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val apiHelperMock = RadarApiHelperMock()
+
+    private fun verifiedTrackResponse(includeTokenFields: Boolean = true): JSONObject {
+        val response = RadarTestUtils.jsonObjectFromResource("/track.json")!!
+            .put("meta", JSONObject())
+
+        if (includeTokenFields) {
+            response.put("token", "verified.jwt.token")
+            response.put("expiresAt", "2026-12-31T23:59:59.000Z")
+            response.put("expiresIn", 3600)
+            response.put("passed", true)
+            response.put("failureReasons", JSONArray())
+        }
+
+        return response
+    }
+
+    private fun incompleteTrackResponse(): JSONObject {
+        val response = RadarTestUtils.jsonObjectFromResource("/track.json")!!
+            .put("meta", JSONObject())
+        response.remove("events")
+        return response
+    }
 
     @Before
     fun setUp() {
@@ -199,5 +223,153 @@ class RadarVerifiedHostOverrideTest {
         assertFalse(apiHelperMock.lastCapturedVerified)
         assertFalse(apiHelperMock.lastUrl?.startsWith(secondary) ?: false)
         assertTrue(apiHelperMock.lastUrl?.startsWith("https://api.radar.io") ?: false)
+    }
+
+    @Test
+    fun `verified track with token succeeds on primary host`() {
+        apiHelperMock.mockResponse = verifiedTrackResponse()
+
+        var observedStatus: Radar.RadarStatus? = null
+        var observedToken: io.radar.sdk.model.RadarVerifiedLocationToken? = null
+        Radar.apiClient.track(
+            location = Location("test"),
+            stopped = false,
+            foreground = true,
+            source = Radar.RadarLocationSource.FOREGROUND_LOCATION,
+            replayed = false,
+            beacons = null,
+            verified = true,
+            callback = object : RadarApiClient.RadarTrackApiCallback {
+                override fun onComplete(
+                    status: Radar.RadarStatus,
+                    res: JSONObject?,
+                    events: Array<io.radar.sdk.model.RadarEvent>?,
+                    user: io.radar.sdk.model.RadarUser?,
+                    nearbyGeofences: Array<io.radar.sdk.model.RadarGeofence>?,
+                    config: io.radar.sdk.model.RadarConfig?,
+                    token: io.radar.sdk.model.RadarVerifiedLocationToken?
+                ) {
+                    observedStatus = status
+                    observedToken = token
+                }
+            }
+        )
+
+        assertEquals(Radar.RadarStatus.SUCCESS, observedStatus)
+        assertNotNull(observedToken)
+        assertEquals("verified.jwt.token", observedToken?.token)
+    }
+
+    @Test
+    fun `verified track without parseable token returns error`() {
+        apiHelperMock.mockResponse = verifiedTrackResponse(includeTokenFields = false)
+
+        var observedStatus: Radar.RadarStatus? = null
+        var observedToken: io.radar.sdk.model.RadarVerifiedLocationToken? = null
+        Radar.apiClient.track(
+            location = Location("test"),
+            stopped = false,
+            foreground = true,
+            source = Radar.RadarLocationSource.FOREGROUND_LOCATION,
+            replayed = false,
+            beacons = null,
+            verified = true,
+            callback = object : RadarApiClient.RadarTrackApiCallback {
+                override fun onComplete(
+                    status: Radar.RadarStatus,
+                    res: JSONObject?,
+                    events: Array<io.radar.sdk.model.RadarEvent>?,
+                    user: io.radar.sdk.model.RadarUser?,
+                    nearbyGeofences: Array<io.radar.sdk.model.RadarGeofence>?,
+                    config: io.radar.sdk.model.RadarConfig?,
+                    token: io.radar.sdk.model.RadarVerifiedLocationToken?
+                ) {
+                    observedStatus = status
+                    observedToken = token
+                }
+            }
+        )
+
+        assertEquals(Radar.RadarStatus.ERROR_SERVER, observedStatus)
+        assertNull(observedToken)
+    }
+
+    @Test
+    fun `non verified track with incomplete payload returns error`() {
+        apiHelperMock.mockResponse = incompleteTrackResponse()
+
+        var observedStatus: Radar.RadarStatus? = null
+        Radar.apiClient.track(
+            location = Location("test"),
+            stopped = false,
+            foreground = true,
+            source = Radar.RadarLocationSource.FOREGROUND_LOCATION,
+            replayed = false,
+            beacons = null,
+            verified = false,
+            callback = object : RadarApiClient.RadarTrackApiCallback {
+                override fun onComplete(
+                    status: Radar.RadarStatus,
+                    res: JSONObject?,
+                    events: Array<io.radar.sdk.model.RadarEvent>?,
+                    user: io.radar.sdk.model.RadarUser?,
+                    nearbyGeofences: Array<io.radar.sdk.model.RadarGeofence>?,
+                    config: io.radar.sdk.model.RadarConfig?,
+                    token: io.radar.sdk.model.RadarVerifiedLocationToken?
+                ) {
+                    observedStatus = status
+                }
+            }
+        )
+
+        assertEquals(Radar.RadarStatus.ERROR_SERVER, observedStatus)
+    }
+
+    @Test
+    fun `verified track can succeed on secondary host after non radar config response`() {
+        val secondary = RadarSettings.getDefaultVerifiedHostSecondary()
+        apiHelperMock.mockResponse = JSONObject().put("error", "not a radar response")
+
+        var observedConfig: io.radar.sdk.model.RadarConfig? = null
+        Radar.apiClient.getConfig("trackVerified", true, null, object : RadarApiClient.RadarGetConfigApiCallback {
+            override fun onComplete(status: Radar.RadarStatus, config: io.radar.sdk.model.RadarConfig?) {
+                observedConfig = config
+            }
+        })
+
+        assertNull(observedConfig)
+
+        apiHelperMock.mockResponse = verifiedTrackResponse()
+
+        var observedStatus: Radar.RadarStatus? = null
+        var observedToken: io.radar.sdk.model.RadarVerifiedLocationToken? = null
+        Radar.apiClient.track(
+            location = Location("test"),
+            stopped = false,
+            foreground = true,
+            source = Radar.RadarLocationSource.FOREGROUND_LOCATION,
+            replayed = false,
+            beacons = null,
+            verified = true,
+            verifiedHostOverride = secondary,
+            callback = object : RadarApiClient.RadarTrackApiCallback {
+                override fun onComplete(
+                    status: Radar.RadarStatus,
+                    res: JSONObject?,
+                    events: Array<io.radar.sdk.model.RadarEvent>?,
+                    user: io.radar.sdk.model.RadarUser?,
+                    nearbyGeofences: Array<io.radar.sdk.model.RadarGeofence>?,
+                    config: io.radar.sdk.model.RadarConfig?,
+                    token: io.radar.sdk.model.RadarVerifiedLocationToken?
+                ) {
+                    observedStatus = status
+                    observedToken = token
+                }
+            }
+        )
+
+        assertTrue(apiHelperMock.lastUrl?.startsWith("$secondary/v1/track") ?: false)
+        assertEquals(Radar.RadarStatus.SUCCESS, observedStatus)
+        assertNotNull(observedToken)
     }
 }


### PR DESCRIPTION
## Summary

Fixes a regression in the verified failover path where `trackVerified()` could successfully fail over to the secondary verified host, receive a valid verified token, and still drop the token instead of returning it to the caller.

The fix keeps normal `track()` behavior unchanged and scopes the new success logic to verified requests only:
- verified `track()` now treats a parsed `RadarVerifiedLocationToken` as the source of truth for success
- verified callbacks return `SUCCESS` when a token is present, even if the response does not satisfy the normal top-level `track()` success gate
- verified requests still fail if token parsing fails
- non-verified `track()` keeps the existing stricter success contract

## Implementation

- Update `RadarApiClient.track()` to add a verified-only success branch keyed off `token != null`
- Use the token's embedded `user` and `events` for downstream verified success handling
- Keep replay, offline handling, failover host selection, and `RadarVerificationManager` flow unchanged

## Tests

Added focused regression coverage in `RadarVerifiedHostOverrideTest` for:
- verified success on the primary host when a valid token is returned
- verified failure when the HTTP response succeeds but token parsing fails
- non-verified incomplete payloads continuing to fail
- verified success on the secondary host after a non-Radar config response on the primary

## Verification

- `./gradlew :sdk:testDebugUnitTest --tests io.radar.sdk.RadarVerifiedHostOverrideTest`
