### PR TITLE
FENCE-2834: Update release actions for Node 24

### DIFF
--- a/.github/workflows/radar-release-actions.yml
+++ b/.github/workflows/radar-release-actions.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       # Prepare Environment
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Configure Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'microsoft'


### PR DESCRIPTION
## Summary
- update the Android release workflow to use Node 24-compatible GitHub Actions
- bump actions/checkout from v2 to v5
- bump actions/setup-java from v2 to v5