### PR TITLE
Add onIpChanged() receiver and setUserLanguage()

### DIFF
--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -59,6 +59,10 @@ class MainActivity : AppCompatActivity() {
         val verifiedReceiver = object : RadarVerifiedReceiver() {
             override fun onTokenUpdated(context: Context, token: RadarVerifiedLocationToken) {
             }
+
+            override fun onIpChanged(context: Context) {
+                Log.v("example", "RadarVerifiedReceiver: onIpChanged")
+            }
         }
         Radar.setVerifiedReceiver(verifiedReceiver)
 

--- a/example/src/main/java/io/radar/example/MainActivity.kt
+++ b/example/src/main/java/io/radar/example/MainActivity.kt
@@ -63,6 +63,10 @@ class MainActivity : AppCompatActivity() {
             override fun onIpChanged(context: Context) {
                 Log.v("example", "RadarVerifiedReceiver: onIpChanged")
             }
+
+            override fun onSharingChanged(context: Context, sharing: Boolean) {
+                Log.v("example", "RadarVerifiedReceiver: onSharingChanged | sharing = $sharing")
+            }
         }
         Radar.setVerifiedReceiver(verifiedReceiver)
 

--- a/example/src/main/java/io/radar/example/TestView.kt
+++ b/example/src/main/java/io/radar/example/TestView.kt
@@ -107,6 +107,10 @@ fun TestView() {
             }
         }
 
+        CustomButton("clearSharing") {
+            Radar.clearSharing()
+        }
+
         CustomButton("setExpectedJurisdiction") {
             Radar.setExpectedJurisdiction("US", "CA")
         }

--- a/example/src/main/java/io/radar/example/TestView.kt
+++ b/example/src/main/java/io/radar/example/TestView.kt
@@ -94,14 +94,6 @@ fun TestView() {
             Radar.stopTrackingVerified()
         }
 
-        CustomButton("startVerifiedChangeListeners") {
-            Radar.startVerifiedChangeListeners()
-        }
-
-        CustomButton("stopVerifiedChangeListeners") {
-            Radar.stopVerifiedChangeListeners()
-        }
-
         CustomButton("getVerifiedLocationToken") {
             Radar.getVerifiedLocationToken { status, token ->
                 Log.v("example", "GetVerifiedLocationToken: status = $status; token = ${token?.toJson()}")

--- a/example/src/main/java/io/radar/example/TestView.kt
+++ b/example/src/main/java/io/radar/example/TestView.kt
@@ -94,6 +94,14 @@ fun TestView() {
             Radar.stopTrackingVerified()
         }
 
+        CustomButton("startMonitoringIpChanges") {
+            Radar.startMonitoringIpChanges()
+        }
+
+        CustomButton("stopMonitoringIpChanges") {
+            Radar.stopMonitoringIpChanges()
+        }
+
         CustomButton("getVerifiedLocationToken") {
             Radar.getVerifiedLocationToken { status, token ->
                 Log.v("example", "GetVerifiedLocationToken: status = $status; token = ${token?.toJson()}")

--- a/example/src/main/java/io/radar/example/TestView.kt
+++ b/example/src/main/java/io/radar/example/TestView.kt
@@ -94,12 +94,12 @@ fun TestView() {
             Radar.stopTrackingVerified()
         }
 
-        CustomButton("startMonitoringIpChanges") {
-            Radar.startMonitoringIpChanges()
+        CustomButton("startVerifiedChangeListeners") {
+            Radar.startVerifiedChangeListeners()
         }
 
-        CustomButton("stopMonitoringIpChanges") {
-            Radar.stopMonitoringIpChanges()
+        CustomButton("stopVerifiedChangeListeners") {
+            Radar.stopVerifiedChangeListeners()
         }
 
         CustomButton("getVerifiedLocationToken") {
@@ -109,6 +109,7 @@ fun TestView() {
         }
 
         CustomButton("trackVerified") {
+            Log.v("example", "screen sharing: ${Radar.isSharing()}")
             Radar.trackVerified(false) { status, token ->
                 Log.v("example", "TrackVerified: status = $status; token = ${token?.toJson()}")
             }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext {
-    radarVersion = '3.33.0-beta.2'
+    radarVersion = '3.33.0-beta.3'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext {
-    radarVersion = '3.33.0-beta.1'
+    radarVersion = '3.33.0-beta.2'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext {
-    radarVersion = '3.32.3'
+    radarVersion = '3.33.0-beta.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext {
-    radarVersion = '3.33.0-beta.3'
+    radarVersion = '3.33.0'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -819,6 +819,34 @@ object Radar {
     }
 
     /**
+     * Sets the user's preferred language. Pass a BCP-47 language tag like `"en"`, `"es"`, or `"es-MX"`.
+     *
+     * @param[userLanguage] The user's preferred language. If null, the previous `userLanguage` will be cleared.
+     */
+    @JvmStatic
+    fun setUserLanguage(userLanguage: String?) {
+        if (!initialized) {
+            return
+        }
+
+        RadarSettings.setUserLanguage(context, userLanguage)
+    }
+
+    /**
+     * Returns the current `userLanguage`.
+     *
+     * @return The current `userLanguage`.
+     */
+    @JvmStatic
+    fun getUserLanguage(): String? {
+        if (!initialized) {
+            return null
+        }
+
+        return RadarSettings.getUserLanguage(context)
+    }
+
+    /**
      * Sets an optional description for the user, displayed in the dashboard.
      *
      * @see [](https://radar.com/documentation/sdk/android#identify-user)
@@ -1437,6 +1465,48 @@ object Radar {
         }
 
         this.verificationManager.stopTrackingVerified()
+    }
+
+    /**
+     * Starts monitoring for changes to the device's IP address. When the IP changes, `onIpChanged` is delivered to the verified receiver. If verified tracking is started, an IP change will also trigger a `trackVerified` call.
+     *
+     * `startTrackingVerified` automatically starts IP change monitoring, and `stopTrackingVerified` stops it.
+     *
+     * @see [](https://radar.com/documentation/fraud)
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @JvmStatic
+    fun startMonitoringIpChanges() {
+        if (!initialized) {
+            return
+        }
+        this.logger.i("startMonitoringIpChanges()", RadarLogType.SDK_CALL)
+
+        if (!this::verificationManager.isInitialized) {
+            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+        }
+
+        this.verificationManager.startMonitoringIpChanges()
+    }
+
+    /**
+     * Stops monitoring for changes to the device's IP address.
+     *
+     * @see [](https://radar.com/documentation/fraud)
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @JvmStatic
+    fun stopMonitoringIpChanges() {
+        if (!initialized) {
+            return
+        }
+        this.logger.i("stopMonitoringIpChanges()", RadarLogType.SDK_CALL)
+
+        if (!this::verificationManager.isInitialized) {
+            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+        }
+
+        this.verificationManager.stopMonitoringIpChanges()
     }
 
     /**
@@ -4336,6 +4406,12 @@ object Radar {
         verifiedReceiver?.onTokenUpdated(context, token)
 
         logger.i("📍️ Radar token updated | passed = ${token.passed}; expiresAt = ${token.expiresAt}; expiresIn = ${token.expiresIn}; token = ${token.token}")
+    }
+
+    internal fun sendIpChanged() {
+        verifiedReceiver?.onIpChanged(context)
+
+        logger.i("📍️ Radar IP changed")
     }
 
     internal fun setLogPersistenceFeatureFlag(enabled: Boolean) {

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1937,6 +1937,7 @@ object Radar {
      *
      * @param[verifiedReceiver] A delegate for client-side delivery of of verified location tokens. If `null`, the previous receiver will be cleared.
      */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
     fun setVerifiedReceiver(verifiedReceiver: RadarVerifiedReceiver?) {
         if (!initialized) {

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -701,6 +701,14 @@ object Radar {
             RadarSettings.setNetworkTimeoutMs(this.context, clamped)
         }
 
+        options.ipChangeDebounceInterval?.let { desiredInterval ->
+            if (!desiredInterval.isFinite() || desiredInterval.isNegative()) {
+                this.logger.d("ipChangeDebounceInterval ignored: must be finite and non-negative | value = $desiredInterval")
+                return@let
+            }
+            RadarSettings.setIpChangeDebounceIntervalMs(this.context, desiredInterval.inWholeMilliseconds)
+        }
+
         activityLifecycleCallbacks?.let {
             application?.unregisterActivityLifecycleCallbacks(it)
         }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1468,46 +1468,6 @@ object Radar {
     }
 
     /**
-     * Starts listeners for `RadarVerifiedReceiver`.
-     *
-     * @see [](https://radar.com/documentation/fraud)
-     */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    @JvmStatic
-    fun startVerifiedChangeListeners() {
-        if (!initialized) {
-            return
-        }
-        this.logger.i("startVerifiedChangeListeners()", RadarLogType.SDK_CALL)
-
-        if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
-        }
-
-        this.verificationManager.startMonitoringIpChanges()
-    }
-
-    /**
-     * Stops listeners for `RadarVerifiedReceiver`.
-     *
-     * @see [](https://radar.com/documentation/fraud)
-     */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    @JvmStatic
-    fun stopVerifiedChangeListeners() {
-        if (!initialized) {
-            return
-        }
-        this.logger.i("stopVerifiedChangeListeners()", RadarLogType.SDK_CALL)
-
-        if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
-        }
-
-        this.verificationManager.stopMonitoringIpChanges()
-    }
-
-    /**
      * Returns a boolean indicating whether verified tracking has been started.
      *
      * @see [](https://radar.com/documentation/fraud)
@@ -1984,6 +1944,17 @@ object Radar {
         }
 
         this.verifiedReceiver = verifiedReceiver
+
+        if (this::verificationManager.isInitialized) {
+            this.verificationManager.updateMonitoringState()
+        } else if (verifiedReceiver != null) {
+            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager.updateMonitoringState()
+        }
+    }
+
+    internal fun hasVerifiedReceiver(): Boolean {
+        return this.verifiedReceiver != null
     }
 
     /**

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1468,19 +1468,17 @@ object Radar {
     }
 
     /**
-     * Starts monitoring for changes to the device's IP address. When the IP changes, `onIpChanged` is delivered to the verified receiver. If verified tracking is started, an IP change will also trigger a `trackVerified` call.
-     *
-     * `startTrackingVerified` automatically starts IP change monitoring, and `stopTrackingVerified` stops it.
+     * Starts listeners for `RadarVerifiedReceiver`.
      *
      * @see [](https://radar.com/documentation/fraud)
      */
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
-    fun startMonitoringIpChanges() {
+    fun startVerifiedChangeListeners() {
         if (!initialized) {
             return
         }
-        this.logger.i("startMonitoringIpChanges()", RadarLogType.SDK_CALL)
+        this.logger.i("startVerifiedChangeListeners()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
             this.verificationManager = RadarVerificationManager(this.context, this.logger)
@@ -1490,17 +1488,17 @@ object Radar {
     }
 
     /**
-     * Stops monitoring for changes to the device's IP address.
+     * Stops listeners for `RadarVerifiedReceiver`.
      *
      * @see [](https://radar.com/documentation/fraud)
      */
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
-    fun stopMonitoringIpChanges() {
+    fun stopVerifiedChangeListeners() {
         if (!initialized) {
             return
         }
-        this.logger.i("stopMonitoringIpChanges()", RadarLogType.SDK_CALL)
+        this.logger.i("stopVerifiedChangeListeners()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
             this.verificationManager = RadarVerificationManager(this.context, this.logger)
@@ -4412,6 +4410,12 @@ object Radar {
         verifiedReceiver?.onIpChanged(context)
 
         logger.i("📍️ Radar IP changed")
+    }
+
+    internal fun sendSharingChanged(sharing: Boolean) {
+        verifiedReceiver?.onSharingChanged(context, sharing)
+
+        logger.i("📍️ Radar sharing changed | sharing = $sharing")
     }
 
     internal fun setLogPersistenceFeatureFlag(enabled: Boolean) {

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -819,7 +819,7 @@ object Radar {
     }
 
     /**
-     * Sets the user's preferred language. Pass a BCP-47 language tag like `"en"`, `"es"`, or `"es-MX"`.
+     * Sets the user's preferred language. Pass a BCP-47 language tag like `"en"` or `"es-PR"`.
      *
      * @param[userLanguage] The user's preferred language. If null, the previous `userLanguage` will be cleared.
      */

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -152,10 +152,6 @@ internal class RadarApiClient(
         if (product != null) {
             headers["X-Radar-Product"] = product
         }
-        val userLanguage = RadarSettings.getUserLanguage(context)
-        if (userLanguage != null) {
-            headers["X-Radar-User-Language"] = userLanguage
-        }
         return headers
     }
 
@@ -388,6 +384,7 @@ internal class RadarApiClient(
             params.putOpt("country", RadarUtils.country)
             params.putOpt("timeZoneOffset", RadarUtils.timeZoneOffset)
             params.putOpt("source", Radar.stringForSource(source))
+            params.putOpt("lang", RadarSettings.getUserLanguage(context))
             if (RadarSettings.isXPlatform(context)) {
                 params.putOpt("xPlatformType", RadarSettings.getXPlatformSDKType(context))
                 params.putOpt("xPlatformSDKVersion", RadarSettings.getXPlatformSDKVersion(context))

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -152,6 +152,10 @@ internal class RadarApiClient(
         if (product != null) {
             headers["X-Radar-Product"] = product
         }
+        val userLanguage = RadarSettings.getUserLanguage(context)
+        if (userLanguage != null) {
+            headers["X-Radar-User-Language"] = userLanguage
+        }
         return headers
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarInitializeOptions.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarInitializeOptions.kt
@@ -19,6 +19,7 @@ import kotlin.time.Duration
  * @param[networkTimeout] Connect and base read timeout for Radar API requests.
  *                        If set, the value is persisted. If null, a previously saved value or default (10 seconds) is used.
  * @param[trackVerifiedAutoFailover] A boolean indicating whether `trackVerified()` should retry against a secondary verified host if the primary returns a non-Radar response. Defaults to false.
+ * @param[ipChangeDebounceInterval] Minimum interval between deliveries of `RadarVerifiedReceiver.onIpChanged`. If set, the value is persisted. If null, a previously saved value or default (10 seconds) is used. Pass `Duration.ZERO` to disable throttling (deliver every detected change).
  *
  */
 data class RadarInitializeOptions(
@@ -33,6 +34,7 @@ data class RadarInitializeOptions(
     val activity: Activity? = null,
     val networkTimeout: Duration? = null,
     val trackVerifiedAutoFailover: Boolean = false,
+    val ipChangeDebounceInterval: Duration? = null,
 ) {
     class Builder {
         private var radarReceiver: RadarReceiver? = null
@@ -46,6 +48,7 @@ data class RadarInitializeOptions(
         private var activity: Activity? = null
         private var networkTimeout: Duration? = null
         private var trackVerifiedAutoFailover: Boolean = false
+        private var ipChangeDebounceInterval: Duration? = null
 
         fun radarReceiver(radarReceiver: RadarReceiver) = apply { this.radarReceiver = radarReceiver }
         fun locationProvider(locationProvider: Radar.RadarLocationServicesProvider) = apply { this.locationProvider = locationProvider }
@@ -58,6 +61,7 @@ data class RadarInitializeOptions(
         fun activity(activity: Activity) = apply { this.activity = activity }
         fun networkTimeout(networkTimeout: Duration) = apply { this.networkTimeout = networkTimeout }
         fun trackVerifiedAutoFailover(trackVerifiedAutoFailover: Boolean) = apply { this.trackVerifiedAutoFailover = trackVerifiedAutoFailover }
+        fun ipChangeDebounceInterval(ipChangeDebounceInterval: Duration) = apply { this.ipChangeDebounceInterval = ipChangeDebounceInterval }
 
         fun build() = RadarInitializeOptions(
             radarReceiver = radarReceiver,
@@ -71,6 +75,7 @@ data class RadarInitializeOptions(
             activity = activity,
             networkTimeout = networkTimeout,
             trackVerifiedAutoFailover = trackVerifiedAutoFailover,
+            ipChangeDebounceInterval = ipChangeDebounceInterval,
         )
     }
 

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -17,6 +17,7 @@ internal object RadarSettings {
     private const val KEY_SESSION_ID = "session_id"
     private const val KEY_ID = "radar_user_id"
     private const val KEY_USER_ID = "user_id"
+    private const val KEY_USER_LANGUAGE = "user_language"
     private const val KEY_DESCRIPTION = "user_description"
     private const val KEY_PRODUCT = "product"
     private const val KEY_METADATA = "user_metadata"
@@ -125,6 +126,14 @@ internal object RadarSettings {
 
     internal fun setUserId(context: Context, userId: String?) {
         getSharedPreferences(context).edit { putString(KEY_USER_ID, userId) }
+    }
+
+    internal fun getUserLanguage(context: Context): String? {
+        return getSharedPreferences(context).getString(KEY_USER_LANGUAGE, null)
+    }
+
+    internal fun setUserLanguage(context: Context, userLanguage: String?) {
+        getSharedPreferences(context).edit { putString(KEY_USER_LANGUAGE, userLanguage) }
     }
 
     internal fun getDescription(context: Context): String? {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -463,7 +463,11 @@ internal object RadarSettings {
     }
 
     internal fun setSharing(context: Context, sharing: Boolean) {
+        val previous = getSharedPreferences(context).getBoolean(KEY_SHARING, false)
         getSharedPreferences(context).edit { putBoolean(KEY_SHARING, sharing) }
+        if (previous != sharing) {
+            Radar.sendSharingChanged(sharing)
+        }
     }
 
     internal fun isXPlatform(context: Context): Boolean {

--- a/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSettings.kt
@@ -46,8 +46,10 @@ internal object RadarSettings {
     private const val KEY_FRAUD_ENABLED = "fraudEnabled"
     private const val KEY_TRACK_VERIFIED_AUTO_FAILOVER = "track_verified_auto_failover"
     private const val KEY_NETWORK_TIMEOUT_MS = "network_timeout_ms"
+    private const val KEY_IP_CHANGE_DEBOUNCE_INTERVAL_MS = "ip_change_debounce_interval_ms"
 
     private const val DEFAULT_NETWORK_TIMEOUT_MS = 10000
+    private const val DEFAULT_IP_CHANGE_DEBOUNCE_INTERVAL_MS = 10000L
 
     private const val KEY_OLD_UPDATE_INTERVAL = "dwell_delay"
     private const val KEY_OLD_UPDATE_INTERVAL_RESPONSIVE = 60000
@@ -193,6 +195,14 @@ internal object RadarSettings {
     internal fun setNetworkTimeoutMs(context: Context, timeoutMs: Int) {
         getSharedPreferences(context).edit { putInt(KEY_NETWORK_TIMEOUT_MS, timeoutMs) }
 	}
+
+    internal fun getIpChangeDebounceIntervalMs(context: Context): Long {
+        return getSharedPreferences(context).getLong(KEY_IP_CHANGE_DEBOUNCE_INTERVAL_MS, DEFAULT_IP_CHANGE_DEBOUNCE_INTERVAL_MS)
+    }
+
+    internal fun setIpChangeDebounceIntervalMs(context: Context, intervalMs: Long) {
+        getSharedPreferences(context).edit { putLong(KEY_IP_CHANGE_DEBOUNCE_INTERVAL_MS, intervalMs) }
+    }
 
     internal fun getTrackVerifiedAutoFailover(context: Context): Boolean {
         return getSharedPreferences(context).getBoolean(KEY_TRACK_VERIFIED_AUTO_FAILOVER, false)

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -40,8 +40,13 @@ internal class RadarVerificationManager(
     private var lastTokenElapsedRealtime: Long = 0L
     private var lastTokenBeacons: Boolean = false
     private var lastIPs: String? = null
+    private var lastIpChangedDeliveredAtMs: Long = 0L
     private var expectedCountryCode: String? = null
     private var expectedStateCode: String? = null
+
+    companion object {
+        private const val IP_CHANGE_DELIVERY_INTERVAL_MS = 10_000L
+    }
 
     fun trackVerified(
         beacons: Boolean = false,
@@ -400,7 +405,11 @@ internal class RadarVerificationManager(
             verificationManager.lastIPs = ips
 
             if (changed && ipsValid) {
-                Radar.sendIpChanged()
+                val now = SystemClock.elapsedRealtime()
+                if (now - verificationManager.lastIpChangedDeliveredAtMs >= IP_CHANGE_DELIVERY_INTERVAL_MS) {
+                    verificationManager.lastIpChangedDeliveredAtMs = now
+                    Radar.sendIpChanged()
+                }
             }
 
             if (changed && verificationManager.started) {

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -325,6 +325,44 @@ internal class RadarVerificationManager(
         verificationManager.startedInterval = interval
         verificationManager.startedBeacons = beacons
 
+        startMonitoringIpChanges()
+
+        if (startedInterval < 20) {
+            Radar.locationManager.locationClient.requestLocationUpdates(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, 0, 0, RadarLocationReceiver.getVerifiedLocationPendingIntent(context))
+        }
+
+        if (this.isLastTokenValid()) {
+            this.scheduleNextIntervalWithLastToken()
+        } else {
+            callTrackVerified("start")
+        }
+    }
+
+    fun stopTrackingVerified() {
+        this.started = false
+
+        try {
+            if (startedInterval < 20) {
+                Radar.locationManager.locationClient.removeLocationUpdates(RadarLocationReceiver.getVerifiedLocationPendingIntent(context))
+            }
+
+            stopMonitoringIpChanges()
+
+            runnable?.let {
+                handler.removeCallbacks(it)
+            }
+        } catch (e: Exception) {
+            Radar.logger.e("Error unregistering callbacks", Radar.RadarLogType.SDK_EXCEPTION, e)
+        }
+    }
+
+    fun startMonitoringIpChanges() {
+        val verificationManager = this
+
+        if (networkCallback != null) {
+            return
+        }
+
         val request = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
             .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
@@ -336,11 +374,12 @@ internal class RadarVerificationManager(
         val handleNetworkChange = {
             val ips = verificationManager.getIPs()
             var changed = false
+            val ipsValid = ips != "error"
 
             if (verificationManager.lastIPs == null) {
                 verificationManager.logger.d("First time getting IPs")
                 changed = false
-            } else if (ips == "error") {
+            } else if (!ipsValid) {
                 verificationManager.logger.d("Error getting IPs")
                 changed = true
             } else if (ips != verificationManager.lastIPs) {
@@ -351,7 +390,11 @@ internal class RadarVerificationManager(
             }
             verificationManager.lastIPs = ips
 
-            if (changed) {
+            if (changed && ipsValid) {
+                Radar.sendIpChanged()
+            }
+
+            if (changed && verificationManager.started) {
                 callTrackVerified("ip_change")
             }
         }
@@ -373,36 +416,17 @@ internal class RadarVerificationManager(
         networkCallback?.let {
             connectivityManager.registerNetworkCallback(request, it)
         }
-
-        if (startedInterval < 20) {
-            Radar.locationManager.locationClient.requestLocationUpdates(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, 0, 0, RadarLocationReceiver.getVerifiedLocationPendingIntent(context))
-        }
-
-        if (this.isLastTokenValid()) {
-            this.scheduleNextIntervalWithLastToken()
-        } else {
-            callTrackVerified("start")
-        }
     }
 
-    fun stopTrackingVerified() {
-        this.started = false
-
+    fun stopMonitoringIpChanges() {
         try {
-            if (startedInterval < 20) {
-                Radar.locationManager.locationClient.removeLocationUpdates(RadarLocationReceiver.getVerifiedLocationPendingIntent(context))
-            }
-
             networkCallback?.let {
                 connectivityManager.unregisterNetworkCallback(it)
             }
-
-            runnable?.let {
-                handler.removeCallbacks(it)
-            }
         } catch (e: Exception) {
-            Radar.logger.e("Error unregistering callbacks", Radar.RadarLogType.SDK_EXCEPTION, e)
+            Radar.logger.e("Error unregistering network callback", Radar.RadarLogType.SDK_EXCEPTION, e)
         }
+        networkCallback = null
     }
 
     fun getVerifiedLocationToken(beacons: Boolean, desiredAccuracy: RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy, callback: Radar.RadarTrackVerifiedCallback? = null) {

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -325,7 +325,7 @@ internal class RadarVerificationManager(
         verificationManager.startedInterval = interval
         verificationManager.startedBeacons = beacons
 
-        startMonitoringIpChanges()
+        updateMonitoringState()
 
         if (startedInterval < 20) {
             Radar.locationManager.locationClient.requestLocationUpdates(RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH, 0, 0, RadarLocationReceiver.getVerifiedLocationPendingIntent(context))
@@ -346,7 +346,7 @@ internal class RadarVerificationManager(
                 Radar.locationManager.locationClient.removeLocationUpdates(RadarLocationReceiver.getVerifiedLocationPendingIntent(context))
             }
 
-            stopMonitoringIpChanges()
+            updateMonitoringState()
 
             runnable?.let {
                 handler.removeCallbacks(it)
@@ -356,7 +356,16 @@ internal class RadarVerificationManager(
         }
     }
 
-    fun startMonitoringIpChanges() {
+    fun updateMonitoringState() {
+        val shouldMonitor = this.started || Radar.hasVerifiedReceiver()
+        if (shouldMonitor) {
+            startMonitoringIpChanges()
+        } else {
+            stopMonitoringIpChanges()
+        }
+    }
+
+    private fun startMonitoringIpChanges() {
         val verificationManager = this
 
         if (networkCallback != null) {
@@ -418,7 +427,7 @@ internal class RadarVerificationManager(
         }
     }
 
-    fun stopMonitoringIpChanges() {
+    private fun stopMonitoringIpChanges() {
         try {
             networkCallback?.let {
                 connectivityManager.unregisterNetworkCallback(it)

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -44,10 +44,6 @@ internal class RadarVerificationManager(
     private var expectedCountryCode: String? = null
     private var expectedStateCode: String? = null
 
-    companion object {
-        private const val IP_CHANGE_DELIVERY_INTERVAL_MS = 10_000L
-    }
-
     fun trackVerified(
         beacons: Boolean = false,
         desiredAccuracy: RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM,
@@ -405,8 +401,9 @@ internal class RadarVerificationManager(
             verificationManager.lastIPs = ips
 
             if (changed && ipsValid) {
+                val debounceMs = RadarSettings.getIpChangeDebounceIntervalMs(verificationManager.context)
                 val now = SystemClock.elapsedRealtime()
-                if (now - verificationManager.lastIpChangedDeliveredAtMs >= IP_CHANGE_DELIVERY_INTERVAL_MS) {
+                if (now - verificationManager.lastIpChangedDeliveredAtMs >= debounceMs) {
                     verificationManager.lastIpChangedDeliveredAtMs = now
                     Radar.sendIpChanged()
                 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
@@ -17,4 +17,11 @@ abstract class RadarVerifiedReceiver {
      */
     abstract fun onTokenUpdated(context: Context, token: RadarVerifiedLocationToken)
 
+    /**
+     * Tells the receiver that the device's IP address changed while IP change monitoring is active.
+     *
+     * @param[context] The context.
+     */
+    open fun onIpChanged(context: Context) {}
+
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
@@ -24,4 +24,12 @@ abstract class RadarVerifiedReceiver {
      */
     open fun onIpChanged(context: Context) {}
 
+    /**
+     * Tells the receiver that the value of `Radar.isSharing()` changed.
+     *
+     * @param[context] The context.
+     * @param[sharing] The current screen sharing state.
+     */
+    open fun onSharingChanged(context: Context, sharing: Boolean) {}
+
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerifiedReceiver.kt
@@ -25,7 +25,7 @@ abstract class RadarVerifiedReceiver {
     open fun onIpChanged(context: Context) {}
 
     /**
-     * Tells the receiver that the value of `Radar.isSharing()` changed.
+     * Tells the receiver that the device's screen sharing state changed.
      *
      * @param[context] The context.
      * @param[sharing] The current screen sharing state.


### PR DESCRIPTION
## Summary

- Adds `RadarVerifiedReceiver.onIpChanged(context)` and `onSharingChanged(context, sharing)`. Both are `open` with default no-op bodies, so existing subclasses are unaffected.
- IP monitoring auto-starts when `setVerifiedReceiver` is called with a non-null receiver, OR while `startTrackingVerified` is active. Clearing the receiver auto-stops it (unless verified tracking is still active). `startTrackingVerified` continues to trigger `trackVerified` on IP change as before.
- `onSharingChanged` fires from `RadarSettings.setSharing` whenever the persisted sharing state transitions (set on virtual-input touches in `RadarActivityLifecycleCallbacks`, cleared via `Radar.clearSharing()` or session refresh).
- Adds `Radar.setUserLanguage(_)` / `getUserLanguage()` backed by `RadarSettings`. When set, the value is sent as `lang` on `POST /track`. Pass-through, so any BCP-47 tag works (e.g. `"en"`, `"es-PR"`).

Mirrors the iOS changes in https://github.com/radarlabs/radar-sdk-ios/pull/601.