### PR TITLE
FENCE-2370: Add campaign scheduling windows for geofence notifications

### DIFF
--- a/sdk/ktlint-baseline.xml
+++ b/sdk/ktlint-baseline.xml
@@ -274,28 +274,28 @@
         <error line="3" column="1" source="standard:import-ordering" />
         <error line="11" column="1" source="standard:no-unused-imports" />
         <error line="12" column="1" source="standard:no-unused-imports" />
-        <error line="26" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="28" column="1" source="standard:no-trailing-spaces" />
-        <error line="29" column="9" source="standard:spacing-between-declarations-with-comments" />
-        <error line="32" column="11" source="standard:no-trailing-spaces" />
-        <error line="38" column="1" source="standard:no-trailing-spaces" />
-        <error line="39" column="9" source="standard:spacing-between-declarations-with-comments" />
-        <error line="41" column="11" source="standard:no-trailing-spaces" />
-        <error line="44" column="71" source="standard:function-expression-body" />
-        <error line="55" column="1" source="standard:no-empty-first-line-in-method-block" />
-        <error line="55" column="1" source="standard:no-trailing-spaces" />
-        <error line="58" column="1" source="standard:no-trailing-spaces" />
-        <error line="68" column="88" source="standard:no-semi" />
-        <error line="104" column="35" source="standard:wrapping" />
-        <error line="104" column="35" source="standard:argument-list-wrapping" />
-        <error line="107" column="53" source="standard:wrapping" />
-        <error line="107" column="54" source="standard:argument-list-wrapping" />
-        <error line="110" column="1" source="standard:no-trailing-spaces" />
-        <error line="115" column="1" source="standard:no-trailing-spaces" />
-        <error line="136" column="1" source="standard:no-empty-first-line-in-method-block" />
-        <error line="136" column="1" source="standard:no-trailing-spaces" />
-        <error line="148" column="1" source="standard:no-trailing-spaces" />
-        <error line="154" column="1" source="standard:no-blank-line-before-rbrace" />
+        <error line="28" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="30" column="1" source="standard:no-trailing-spaces" />
+        <error line="31" column="9" source="standard:spacing-between-declarations-with-comments" />
+        <error line="34" column="11" source="standard:no-trailing-spaces" />
+        <error line="40" column="1" source="standard:no-trailing-spaces" />
+        <error line="41" column="9" source="standard:spacing-between-declarations-with-comments" />
+        <error line="43" column="11" source="standard:no-trailing-spaces" />
+        <error line="46" column="71" source="standard:function-expression-body" />
+        <error line="73" column="1" source="standard:no-empty-first-line-in-method-block" />
+        <error line="73" column="1" source="standard:no-trailing-spaces" />
+        <error line="76" column="1" source="standard:no-trailing-spaces" />
+        <error line="86" column="88" source="standard:no-semi" />
+        <error line="122" column="35" source="standard:wrapping" />
+        <error line="122" column="35" source="standard:argument-list-wrapping" />
+        <error line="125" column="53" source="standard:wrapping" />
+        <error line="125" column="54" source="standard:argument-list-wrapping" />
+        <error line="128" column="1" source="standard:no-trailing-spaces" />
+        <error line="133" column="1" source="standard:no-trailing-spaces" />
+        <error line="156" column="1" source="standard:no-empty-first-line-in-method-block" />
+        <error line="156" column="1" source="standard:no-trailing-spaces" />
+        <error line="168" column="1" source="standard:no-trailing-spaces" />
+        <error line="174" column="1" source="standard:no-blank-line-before-rbrace" />
     </file>
     <file name="src/main/java/io/radar/sdk/RadarNotificationOptions.kt">
         <error line="3" column="1" source="standard:import-ordering" />
@@ -587,7 +587,6 @@
         <error line="159" column="45" source="standard:no-multi-spaces" />
         <error line="160" column="39" source="standard:no-multi-spaces" />
         <error line="161" column="40" source="standard:no-multi-spaces" />
-        <error line="271" column="1" source="standard:final-newline" />
     </file>
     <file name="src/main/java/io/radar/sdk/RadarVerificationManager.kt">
         <error line="3" column="1" source="standard:import-ordering" />

--- a/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarNotificationHelper.kt
@@ -15,6 +15,8 @@ import androidx.core.app.NotificationCompat
 import io.radar.sdk.model.RadarEvent
 import androidx.core.net.toUri
 import androidx.core.graphics.toColorInt
+import org.json.JSONObject
+import java.util.Date
 
 class RadarNotificationHelper {
 
@@ -43,6 +45,22 @@ class RadarNotificationHelper {
          */
         internal fun getCustomForegroundNotification(): Notification? {
             return customForegroundNotification
+        }
+
+        private fun isWithinSchedulingWindow(metadata: JSONObject?): Boolean {
+            if (metadata == null) return true
+            val now = Date()
+            val startsAtStr = metadata.optString("radar:startsAt").takeIf { it.isNotEmpty() }
+            val endsAtStr = metadata.optString("radar:endsAt").takeIf { it.isNotEmpty() }
+            if (startsAtStr != null) {
+                val startsAt = RadarUtils.naiveLocalIsoStringToDate(startsAtStr) ?: return true
+                if (now.before(startsAt)) return false
+            }
+            if (endsAtStr != null) {
+                val endsAt = RadarUtils.naiveLocalIsoStringToDate(endsAtStr) ?: return true
+                if (now.after(endsAt)) return false
+            }
+            return true
         }
 
         @SuppressLint("DiscouragedApi", "LaunchActivityFromNotification")
@@ -119,8 +137,10 @@ class RadarNotificationHelper {
                 }
 
                 if (event.type == RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE) {
+                    if (!isWithinSchedulingWindow(event.geofence?.metadata)) continue
                     notificationText = event.geofence?.metadata?.optString("radar:entryNotificationText")
                 } else if (event.type == RadarEvent.RadarEventType.USER_EXITED_GEOFENCE) {
+                    if (!isWithinSchedulingWindow(event.geofence?.metadata)) continue
                     notificationText = event.geofence?.metadata?.optString("radar:exitNotificationText")
                 } else if (event.type == RadarEvent.RadarEventType.USER_ENTERED_BEACON) {
                     notificationText = event.beacon?.metadata?.optString("radar:entryNotificationText")

--- a/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarUtils.kt
@@ -174,6 +174,15 @@ internal object RadarUtils {
         return null
     }
 
+    internal fun naiveLocalIsoStringToDate(str: String?): Date? {
+        if (str == null) return null
+        return try {
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).parse(str)
+        } catch (_: ParseException) {
+            null
+        }
+    }
+
     internal fun dateToISOString(date: Date?): String? {
         if (date == null) {
             return null

--- a/sdk/src/test/java/io/radar/sdk/RadarNotificationHelperTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarNotificationHelperTest.kt
@@ -1,0 +1,225 @@
+package io.radar.sdk
+
+import android.app.NotificationManager
+import android.content.Context
+import android.location.Location
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.radar.sdk.model.RadarBeacon
+import io.radar.sdk.model.RadarEvent
+import io.radar.sdk.model.RadarGeofence
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowNotificationManager
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class RadarNotificationHelperTest {
+
+    private lateinit var context: Context
+    private lateinit var shadowNotificationManager: ShadowNotificationManager
+    private val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        shadowNotificationManager = Shadows.shadowOf(notificationManager)
+    }
+
+    private fun relativeTimestamp(offsetMs: Long): String = fmt.format(Date(System.currentTimeMillis() + offsetMs))
+
+    private fun makeGeofenceWithMetadata(metadata: JSONObject?): RadarGeofence = RadarGeofence("geo1", "Test Geofence", null, null, metadata, null, null)
+
+    private fun makeBeaconWithMetadata(metadata: JSONObject?): RadarBeacon = RadarBeacon(uuid = "uuid", major = "1", minor = "1", metadata = metadata, type = RadarBeacon.RadarBeaconType.IBEACON)
+
+    private fun makeGeofenceEvent(
+        type: RadarEvent.RadarEventType,
+        geofence: RadarGeofence
+    ): RadarEvent = RadarEvent(
+        _id = "event1",
+        createdAt = Date(),
+        actualCreatedAt = Date(),
+        live = false,
+        type = type,
+        conversionName = null,
+        geofence = geofence,
+        place = null,
+        region = null,
+        beacon = null,
+        trip = null,
+        fraud = null,
+        alternatePlaces = null,
+        verifiedPlace = null,
+        verification = RadarEvent.RadarEventVerification.ACCEPT,
+        confidence = RadarEvent.RadarEventConfidence.HIGH,
+        duration = 0f,
+        location = Location("test"),
+        replayed = false,
+        metadata = null
+    )
+
+    private fun makeBeaconEvent(
+        type: RadarEvent.RadarEventType,
+        beacon: RadarBeacon
+    ): RadarEvent = RadarEvent(
+        _id = "event2",
+        createdAt = Date(),
+        actualCreatedAt = Date(),
+        live = false,
+        type = type,
+        conversionName = null,
+        geofence = null,
+        place = null,
+        region = null,
+        beacon = beacon,
+        trip = null,
+        fraud = null,
+        alternatePlaces = null,
+        verifiedPlace = null,
+        verification = RadarEvent.RadarEventVerification.ACCEPT,
+        confidence = RadarEvent.RadarEventConfidence.HIGH,
+        duration = 0f,
+        location = Location("test"),
+        replayed = false,
+        metadata = null
+    )
+
+    private fun notificationCount(): Int = shadowNotificationManager.allNotifications.size
+
+    // --- No scheduling window ---
+
+    @Test
+    fun `geofence entry notification shown when no scheduling window set`() {
+        val metadata = JSONObject().apply { put("radar:entryNotificationText", "You entered!") }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(1, notificationCount())
+    }
+
+    // --- Within window ---
+
+    @Test
+    fun `geofence entry notification shown when within scheduling window`() {
+        val metadata = JSONObject().apply {
+            put("radar:entryNotificationText", "You entered!")
+            put("radar:startsAt", relativeTimestamp(-60_000)) // 1 min ago
+            put("radar:endsAt", relativeTimestamp(60_000)) // 1 min from now
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(1, notificationCount())
+    }
+
+    // --- Before window starts ---
+
+    @Test
+    fun `geofence entry notification suppressed when before startsAt`() {
+        val metadata = JSONObject().apply {
+            put("radar:entryNotificationText", "You entered!")
+            put("radar:startsAt", relativeTimestamp(60_000)) // 1 min from now
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(0, notificationCount())
+    }
+
+    // --- After window ends ---
+
+    @Test
+    fun `geofence entry notification suppressed when after endsAt`() {
+        val metadata = JSONObject().apply {
+            put("radar:entryNotificationText", "You entered!")
+            put("radar:endsAt", relativeTimestamp(-60_000)) // 1 min ago
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(0, notificationCount())
+    }
+
+    // --- Exit event respects window ---
+
+    @Test
+    fun `geofence exit notification suppressed when outside window`() {
+        val metadata = JSONObject().apply {
+            put("radar:exitNotificationText", "You exited!")
+            put("radar:startsAt", relativeTimestamp(60_000)) // future
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_EXITED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(0, notificationCount())
+    }
+
+    @Test
+    fun `geofence exit notification shown when within window`() {
+        val metadata = JSONObject().apply {
+            put("radar:exitNotificationText", "You exited!")
+            put("radar:startsAt", relativeTimestamp(-60_000))
+            put("radar:endsAt", relativeTimestamp(60_000))
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_EXITED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(1, notificationCount())
+    }
+
+    // --- Both set to distant future/past ---
+
+    @Test
+    fun `notification suppressed when both startsAt and endsAt are in the future`() {
+        val metadata = JSONObject().apply {
+            put("radar:entryNotificationText", "You entered!")
+            put("radar:startsAt", relativeTimestamp(3_600_000)) // 1 hour from now
+            put("radar:endsAt", relativeTimestamp(7_200_000)) // 2 hours from now
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(0, notificationCount())
+    }
+
+    @Test
+    fun `notification suppressed when both startsAt and endsAt are in the past`() {
+        val metadata = JSONObject().apply {
+            put("radar:entryNotificationText", "You entered!")
+            put("radar:startsAt", relativeTimestamp(-7_200_000)) // 2 hours ago
+            put("radar:endsAt", relativeTimestamp(-3_600_000)) // 1 hour ago
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(0, notificationCount())
+    }
+
+    // --- Fail-open on bad date ---
+
+    @Test
+    fun `notification shown when startsAt is unparseable (fail-open)`() {
+        val metadata = JSONObject().apply {
+            put("radar:entryNotificationText", "You entered!")
+            put("radar:startsAt", "not-a-date")
+        }
+        val event = makeGeofenceEvent(RadarEvent.RadarEventType.USER_ENTERED_GEOFENCE, makeGeofenceWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(1, notificationCount())
+    }
+
+    // --- Beacon event is NOT affected by window check ---
+
+    @Test
+    fun `beacon entry notification shown regardless of scheduling window fields`() {
+        val metadata = JSONObject().apply {
+            put("radar:entryNotificationText", "Beacon nearby!")
+            put("radar:startsAt", relativeTimestamp(60_000)) // future — should NOT suppress beacon
+        }
+        val event = makeBeaconEvent(RadarEvent.RadarEventType.USER_ENTERED_BEACON, makeBeaconWithMetadata(metadata))
+        RadarNotificationHelper.showNotifications(context, arrayOf(event))
+        assertEquals(1, notificationCount())
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `radar:startsAt` / `radar:endsAt` scheduling window support to client-side geofence entry/exit notifications
- Parses both fields as **naive local datetimes** (no timezone conversion — the literal `Z` suffix is non-functional) using a new `RadarUtils.naiveLocalIsoStringToDate` utility
- Check lives in `RadarNotificationHelper.showNotifications()` inside the `USER_ENTERED_GEOFENCE` and `USER_EXITED_GEOFENCE` branches — fails open (unparseable dates = window absent = notification shown)
- Beacon, trip, and campaign (`eventBased`) notifications are unaffected

Companion PRs: [dashboard#725](https://github.com/radarlabs/dashboard/pull/725) · [server#7902](https://github.com/radarlabs/server/pull/7902)

## Test plan

Requires [server#7902](https://github.com/radarlabs/server/pull/7902) deployed (or a local server with the `radar:startsAt`/`radar:endsAt` metadata fields wired up) and a geofence configured via [dashboard#725](https://github.com/radarlabs/dashboard/pull/725) with a scheduling window.

- [ ] Configure a geofence with `radar:entryNotificationText` and a `radar:startsAt` set **in the future** — trigger an entry event — confirm the notification is **not shown**
- [ ] Configure a geofence with `radar:entryNotificationText` and a `radar:endsAt` set **in the past** — trigger an entry event — confirm the notification is **not shown**
- [ ] Configure a geofence with `radar:entryNotificationText` and a window where `startsAt` is in the past and `endsAt` is in the future — trigger an entry event — confirm the notification **is shown**
- [ ] Configure a geofence with `radar:exitNotificationText` and a scheduling window — trigger an exit event inside and outside the window — confirm suppression/delivery matches the window
- [ ] Configure a geofence with `radar:entryNotificationText` and **no** `radar:startsAt`/`radar:endsAt` — confirm existing behavior is unchanged (notification always shown)
- [ ] Confirm beacon entry/exit and trip notifications are unaffected by any `radar:startsAt`/`radar:endsAt` fields that may be present