### PR TITLE
Fra 2137 adding reveal id to fraud payload

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1784,6 +1784,26 @@ object Radar {
     }
 
     /**
+     * Clears the user's last reveal Risk ID.
+     *
+     * @see [](https://radar.com/documentation/fraud)
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @JvmStatic
+    fun clearRevealRiskId() {
+        if (!initialized) {
+            return
+        }
+        this.logger.i("clearVerifiedLocationToken()", RadarLogType.SDK_CALL)
+
+        if (!this::verificationManager.isInitialized) {
+            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+        }
+
+        RadarSDKFraud.setRevealRiskId(null, logger)
+    }
+
+    /**
      * Optionally sets the user's expected country and state for jurisdiction checks.
      *
      * @param[countryCode] The user's expected country code.

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -696,6 +696,7 @@ internal class RadarApiClient(
                     val result = RadarRevealRiskToken.fromJson(res)
 
                     if (result != null) {
+                        RadarSDKFraud.setRevealRiskId(result.id, logger)
                         callback(RadarStatus.SUCCESS, result)
                     } else {
                         callback(RadarStatus.ERROR_SERVER, null)

--- a/sdk/src/main/java/io/radar/sdk/RadarSDKFraud.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarSDKFraud.kt
@@ -52,5 +52,24 @@ internal class RadarSDKFraud {
                 callback(Radar.RadarStatus.ERROR_PLUGIN, "")
             }
         }
+
+        fun setRevealRiskId(revealRiskId: String?, logger: RadarLogger) {
+            try {
+                val fraudClass = Class.forName("io.radar.sdk.fraud.RadarSDKFraud")
+                val sharedInstanceMethod = fraudClass.getMethod("sharedInstance")
+                val fraudInstance = sharedInstanceMethod.invoke(null)
+
+                val setRevealRiskMethod = fraudClass.getMethod(
+                    "setRevealRiskId",
+                    String::class.java
+                )
+
+                setRevealRiskMethod.invoke(fraudInstance, revealRiskId)
+            } catch (e: ClassNotFoundException) {
+                logger.d("Skipping fraud checks: RadarSDKFraud submodule not available")
+            } catch (e: Exception) {
+                logger.e("Error calling fraud detection ${e.message ?: ""}", Radar.RadarLogType.SDK_EXCEPTION, e)
+            }
+        }
     }
 }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -126,6 +126,7 @@ internal class RadarVerificationManager(
                                                     Radar.locationManager.updateTrackingFromMeta(
                                                         config?.meta
                                                     )
+                                                    RadarSDKFraud.setRevealRiskId(null, logger)
                                                 }
                                                 if (token != null) {
                                                     verificationManager.lastToken = token


### PR DESCRIPTION
<!--
Thanks for contributing to the Radar Android SDK! 💙

External contributors: a Radar team member will review your PR. By contributing you
agree your changes are licensed under this repo's Apache 2.0 license. No CLA needed.

Before opening, please run the same checks CI runs:
  ./gradlew :sdk:ktlintCheck
  ./gradlew :sdk:lintDebug
  ./gradlew test
-->

## Summary

<!-- What does this PR do, and why? Keep it focused. -->

## Linear ticket (Radar internal)

<!-- Internal contributors: link the Linear ticket, e.g. FENCE-1234. External contributors can delete this section. -->

## Related issue

<!-- Link any related GitHub issue, e.g. Closes #123. -->

## Type of change

- [ ] Bug fix (non-breaking)
- [X] New feature (non-breaking)
- [ ] Breaking change (alters existing public API behavior)
- [ ] Documentation / internal only (no SDK behavior change)

## Manual test steps

<!--
How did you verify this? Give steps a reviewer can follow when possible — ideally
via the example app in `example/`. Include device/OS/emulator and any setup.
-->

1. Open example application
2. Run RevealRisk endpoint
3. Run Track Verified endpoint
4. Check fraud payload from Track Verified, the Reveal Risk ID will be in it
5. Run Track Verified a second time
6. No reveal risk in the fraud playload

## Checklist

- [ ] Added or updated unit tests (`./gradlew test`)
- [x] `./gradlew :sdk:ktlintCheck` and `./gradlew :sdk:lintDebug` pass locally
- [ ] For breaking changes: added a `MIGRATION.md` entry and bumped `version` in `sdk/build.gradle`
- [ ] Updated README / public docs if the public API changed
- [x] No real API keys committed in the example app
- [x] Only fixed lint/ktlint violations on lines I changed; removed any now-stale baseline entries

## Screenshots / recordings (optional)

the android fraud sdk changes PR:
https://github.com/radarlabs/radar-sdk-android-fraud/pull/22
