### PR TITLE
FENCE-2946: Retain receivers set before initialization

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'signing'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 ext {
-    radarVersion = '3.36.0'
+    radarVersion = '3.36.1'
 }
 
 String buildNumber = ".${System.currentTimeMillis()}"

--- a/sdk/ktlint-baseline.xml
+++ b/sdk/ktlint-baseline.xml
@@ -1109,7 +1109,7 @@
         <error line="864" column="1" source="standard:final-newline" />
     </file>
     <file name="src/test/java/io/radar/sdk/RadarTest.kt">
-        <error line="56" column="19" source="standard:property-naming" />
+        <error line="59" column="19" source="standard:property-naming" />
     </file>
     <file name="src/test/java/io/radar/sdk/RadarVerifiedHostOverrideTest.kt">
         <error line="49" column="22" source="standard:argument-list-wrapping" />

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -842,7 +842,8 @@ object Radar {
         this.initialized = true
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            verifiedReceiver != null) {
+            verifiedReceiver != null
+        ) {
             updateVerifiedReceiverMonitoringState()
         }
 
@@ -2139,7 +2140,7 @@ object Radar {
 
         updateVerifiedReceiverMonitoringState()
     }
-    
+
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     private fun updateVerifiedReceiverMonitoringState() {
         if (this::verificationManager.isInitialized) {

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -841,7 +841,8 @@ object Radar {
 
         this.initialized = true
 
-        if (verifiedReceiver != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            verifiedReceiver != null) {
             updateVerifiedReceiverMonitoringState()
         }
 
@@ -2138,7 +2139,8 @@ object Radar {
 
         updateVerifiedReceiverMonitoringState()
     }
-
+    
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     private fun updateVerifiedReceiverMonitoringState() {
         if (this::verificationManager.isInitialized) {
             this.verificationManager.updateMonitoringState()

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -841,6 +841,10 @@ object Radar {
 
         this.initialized = true
 
+        if (verifiedReceiver != null) {
+            updateVerifiedReceiverMonitoringState()
+        }
+
         logger.i("📍️ Radar initialized")
     }
 
@@ -2101,39 +2105,46 @@ object Radar {
     /**
      * Sets a receiver for client-side delivery of events, location updates, and debug logs.
      *
+     * May be called before initialization. The receiver will be retained and used
+     * when the SDK initializes.
+     *
      * @see [](https://radar.com/documentation/sdk/android#listening-for-events-with-a-receiver)
      *
      * @param[receiver] A delegate for client-side delivery of events, location updates, and debug logs. If `null`, the previous receiver will be cleared.
      */
     @JvmStatic
     fun setReceiver(receiver: RadarReceiver?) {
-        if (!initialized) {
-            return
-        }
-
         this.receiver = receiver
     }
 
     /**
      * Sets a receiver for client-side delivery of verified location tokens.
      *
+     * May be called before initialization. The receiver will be retained and used
+     * when the SDK initializes.
+     *
      * @see [](https://radar.com/documentation/sdk/fraud)
      *
-     * @param[verifiedReceiver] A delegate for client-side delivery of of verified location tokens. If `null`, the previous receiver will be cleared.
+     * @param[verifiedReceiver] A delegate for client-side delivery of verified location tokens. If `null`, the previous receiver will be cleared.
      */
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
     fun setVerifiedReceiver(verifiedReceiver: RadarVerifiedReceiver?) {
+        this.verifiedReceiver = verifiedReceiver
+
         if (!initialized) {
             return
         }
 
-        this.verifiedReceiver = verifiedReceiver
+        updateVerifiedReceiverMonitoringState()
+    }
 
+    private fun updateVerifiedReceiverMonitoringState() {
         if (this::verificationManager.isInitialized) {
             this.verificationManager.updateMonitoringState()
         } else if (verifiedReceiver != null) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager =
+                RadarVerificationManager(this.context, this.logger)
             this.verificationManager.updateMonitoringState()
         }
     }

--- a/sdk/src/test/java/io/radar/sdk/RadarTest.kt
+++ b/sdk/src/test/java/io/radar/sdk/RadarTest.kt
@@ -3,6 +3,7 @@ package io.radar.sdk
 import android.app.Activity
 import android.content.Context
 import android.location.Location
+import android.net.ConnectivityManager
 import android.os.Build
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
@@ -25,6 +26,7 @@ import io.radar.sdk.model.RadarSegment
 import io.radar.sdk.model.RadarTrip
 import io.radar.sdk.model.RadarTripLeg
 import io.radar.sdk.model.RadarUser
+import io.radar.sdk.model.RadarVerifiedLocationToken
 import java.util.Calendar
 import java.util.Date
 import java.util.EnumSet
@@ -43,6 +45,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 
@@ -287,6 +290,51 @@ class RadarTest {
         assertNotEquals(route?.duration?.value, 0)
     }
 
+    private class RecordingReceiver : RadarReceiver() {
+        var error: Radar.RadarStatus? = null
+
+        override fun onEventsReceived(
+            context: Context,
+            events: Array<RadarEvent>,
+            user: RadarUser?
+        ) {}
+
+        override fun onLocationUpdated(
+            context: Context,
+            location: Location,
+            user: RadarUser
+        ) {}
+
+        override fun onClientLocationUpdated(
+            context: Context,
+            location: Location,
+            stopped: Boolean,
+            source: Radar.RadarLocationSource
+        ) {}
+
+        override fun onError(
+            context: Context,
+            status: Radar.RadarStatus
+        ) {
+            error = status
+        }
+
+        override fun onLog(context: Context, message: String) {}
+    }
+
+    private class RecordingVerifiedReceiver : RadarVerifiedReceiver() {
+        var ipChanged = false
+
+        override fun onTokenUpdated(
+            context: Context,
+            token: RadarVerifiedLocationToken
+        ) {}
+
+        override fun onIpChanged(context: Context) {
+            ipChanged = true
+        }
+    }
+
     @Before
     fun setUp() {
         Radar.logger = RadarLogger(context)
@@ -310,6 +358,132 @@ class RadarTest {
     @Test
     fun test_Radar_initialize() {
         assertEquals(publishableKey, RadarSettings.getPublishableKey(context))
+    }
+
+    @Test
+    fun test_Radar_setReceiver_beforeInitialize() {
+        val receiver = RecordingReceiver()
+        Radar.initialized = false
+
+        try {
+            Radar.setReceiver(receiver)
+
+            assertNull(receiver.error)
+
+            Radar.initialize(context, publishableKey)
+            Radar.sendError(Radar.RadarStatus.ERROR_UNKNOWN)
+
+            assertEquals(Radar.RadarStatus.ERROR_UNKNOWN, receiver.error)
+        } finally {
+            Radar.setReceiver(null)
+        }
+    }
+
+    @Test
+    fun test_Radar_initialize_receiverOverridesPreinitializedReceiver() {
+        val preinitializedReceiver = RecordingReceiver()
+        val initializationReceiver = RecordingReceiver()
+        Radar.initialized = false
+
+        try {
+            Radar.setReceiver(preinitializedReceiver)
+
+            Radar.initialize(
+                context,
+                publishableKey,
+                RadarInitializeOptions(
+                    radarReceiver = initializationReceiver
+                )
+            )
+            Radar.sendError(Radar.RadarStatus.ERROR_UNKNOWN)
+
+            assertNull(preinitializedReceiver.error)
+            assertEquals(
+                Radar.RadarStatus.ERROR_UNKNOWN,
+                initializationReceiver.error
+            )
+        } finally {
+            Radar.setReceiver(null)
+        }
+    }
+
+    @Test
+    fun test_Radar_setReceiver_nullBeforeInitialize() {
+        val receiver = RecordingReceiver()
+        Radar.initialized = false
+
+        try {
+            Radar.setReceiver(receiver)
+            Radar.setReceiver(null)
+
+            Radar.initialize(context, publishableKey)
+            Radar.sendError(Radar.RadarStatus.ERROR_UNKNOWN)
+
+            assertNull(receiver.error)
+        } finally {
+            Radar.setReceiver(null)
+        }
+    }
+
+    @Test
+    fun test_Radar_setVerifiedReceiver_beforeInitialize() {
+        val receiver = RecordingVerifiedReceiver()
+        val connectivityManager =
+            context.getSystemService(
+                Context.CONNECTIVITY_SERVICE
+            ) as ConnectivityManager
+        val shadowConnectivityManager = shadowOf(connectivityManager)
+        val initialCallbackCount =
+            shadowConnectivityManager.networkCallbacks.size
+
+        Radar.initialized = false
+
+        try {
+            Radar.setVerifiedReceiver(receiver)
+
+            assertTrue(Radar.hasVerifiedReceiver())
+            assertFalse(receiver.ipChanged)
+            assertEquals(
+                initialCallbackCount,
+                shadowConnectivityManager.networkCallbacks.size
+            )
+
+            Radar.initialize(context, publishableKey)
+
+            assertEquals(
+                initialCallbackCount + 1,
+                shadowConnectivityManager.networkCallbacks.size
+            )
+
+            Radar.sendIpChanged()
+            assertTrue(receiver.ipChanged)
+        } finally {
+            Radar.setVerifiedReceiver(null)
+        }
+        assertEquals(
+            initialCallbackCount,
+            shadowConnectivityManager.networkCallbacks.size
+        )
+    }
+
+    @Test
+    fun test_Radar_setVerifiedReceiver_nullBeforeInitialize() {
+        val receiver = RecordingVerifiedReceiver()
+        Radar.initialized = false
+
+        try {
+            Radar.setVerifiedReceiver(receiver)
+            Radar.setVerifiedReceiver(null)
+
+            assertFalse(Radar.hasVerifiedReceiver())
+
+            Radar.initialize(context, publishableKey)
+            Radar.sendIpChanged()
+
+            assertFalse(receiver.ipChanged)
+        } finally {
+            Radar.setVerifiedReceiver(null)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- retain `RadarReceiver` and `RadarVerifiedReceiver` instances set before SDK initialization
- start verified receiver monitoring once initialization completes
- preserve receiver overrides supplied through `RadarInitializeOptions`
- add tests for receiver retention, clearing, overrides, and monitoring lifecycle

This enables integrations such as Flutter headless engines to register native receivers before Radar is initialized.

## Testing

- `./gradlew :sdk:testDebugUnitTest --tests io.radar.sdk.RadarTest`
- `./gradlew :sdk:ktlintCheck`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (alters existing public API behavior)
- [ ] Documentation / internal only (no SDK behavior change)

## Checklist

- [x] Added or updated unit tests (`./gradlew test`)
- [x] `./gradlew :sdk:ktlintCheck` and `./gradlew :sdk:lintDebug` pass locally
- [x] For breaking changes: added a `MIGRATION.md` entry and bumped `version` in `sdk/build.gradle`
- [x] Updated README / public docs if the public API changed
- [x] No real API keys committed in the example app
- [x] Only fixed lint/ktlint violations on lines I changed; removed any now-stale baseline entries