### PR TITLE
Added reveal risk to the track verified call.

### DIFF
--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1514,17 +1514,15 @@ object Radar {
         this.logger.i("trackVerified()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager = RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
         }
 
         this.verificationManager.trackVerified(
-            beacons,
-            desiredAccuracy,
-            reason,
-            transactionId,
-            revealRiskManager.getRevealRiskId(),
-            { revealRiskManager.clearRevealRiskId() },
-            callback
+            beacons = beacons,
+            desiredAccuracy = desiredAccuracy,
+            reason = reason,
+            transactionId = transactionId,
+            callback = callback
         )
     }
 
@@ -1582,7 +1580,7 @@ object Radar {
         this.logger.i("startTrackingVerified()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager = RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
         }
 
         this.verificationManager.startTrackingVerified(interval, beacons)
@@ -1602,7 +1600,7 @@ object Radar {
         this.logger.i("stopTrackingVerified()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager = RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
         }
 
         this.verificationManager.stopTrackingVerified()
@@ -1623,7 +1621,7 @@ object Radar {
         }
 
         if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager = RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
         }
 
         return this.verificationManager.started
@@ -1746,7 +1744,7 @@ object Radar {
         this.logger.i("getVerifiedLocationToken()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager = RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
         }
 
         this.verificationManager.getVerifiedLocationToken(beacons, desiredAccuracy, callback)
@@ -1791,7 +1789,7 @@ object Radar {
         this.logger.i("clearVerifiedLocationToken()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager = RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
         }
 
         this.verificationManager.clearVerifiedLocationToken()
@@ -1802,7 +1800,6 @@ object Radar {
      *
      * @see [](https://radar.com/documentation/fraud)
      */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @JvmStatic
     fun clearRevealRiskId() {
         if (!initialized) {
@@ -1828,7 +1825,7 @@ object Radar {
         this.logger.i("setExpectedJurisdiction()", RadarLogType.SDK_CALL)
 
         if (!this::verificationManager.isInitialized) {
-            this.verificationManager = RadarVerificationManager(this.context, this.logger)
+            this.verificationManager = RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
         }
 
         this.verificationManager.setExpectedJurisdiction(countryCode, stateCode)
@@ -2171,7 +2168,7 @@ object Radar {
             this.verificationManager.updateMonitoringState()
         } else if (verifiedReceiver != null) {
             this.verificationManager =
-                RadarVerificationManager(this.context, this.logger)
+                RadarVerificationManager(this.context, this.logger, this.revealRiskManager)
             this.verificationManager.updateMonitoringState()
         }
     }

--- a/sdk/src/main/java/io/radar/sdk/Radar.kt
+++ b/sdk/src/main/java/io/radar/sdk/Radar.kt
@@ -1517,7 +1517,15 @@ object Radar {
             this.verificationManager = RadarVerificationManager(this.context, this.logger)
         }
 
-        this.verificationManager.trackVerified(beacons, desiredAccuracy, reason, transactionId, callback)
+        this.verificationManager.trackVerified(
+            beacons,
+            desiredAccuracy,
+            reason,
+            transactionId,
+            revealRiskManager.getRevealRiskId(),
+            { revealRiskManager.clearRevealRiskId() },
+            callback
+        )
     }
 
     /**
@@ -1787,6 +1795,22 @@ object Radar {
         }
 
         this.verificationManager.clearVerifiedLocationToken()
+    }
+
+    /**
+     * Clears the user's last reveal risk ID.
+     *
+     * @see [](https://radar.com/documentation/fraud)
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @JvmStatic
+    fun clearRevealRiskId() {
+        if (!initialized) {
+            return
+        }
+        this.logger.i("clearRevealRiskId()", RadarLogType.SDK_CALL)
+
+        this.revealRiskManager.clearRevealRiskId()
     }
 
     /**

--- a/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarApiClient.kt
@@ -301,6 +301,7 @@ internal class RadarApiClient(
         expectedStateCode: String? = null,
         reason: String? = null,
         transactionId: String? = null,
+        revealRiskId: String? = null,
         fraudPayload: String? = null,
         callback: RadarTrackApiCallback? = null,
         verifiedHostOverride: String? = null
@@ -416,6 +417,9 @@ internal class RadarApiClient(
                 }
                 if (transactionId != null) {
                     params.putOpt("transactionId", transactionId)
+                }
+                if (revealRiskId != null) {
+                    params.put("revealRiskId", revealRiskId)
                 }
             }
             putApplicationParameters(params)

--- a/sdk/src/main/java/io/radar/sdk/RadarRevealRiskManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarRevealRiskManager.kt
@@ -8,6 +8,18 @@ internal class RadarRevealRiskManager(
     private val context: Context,
     private val logger: RadarLogger
 ) {
+    private var revealRiskId: String? = null
+
+    fun setRevealRiskId(revealRiskId: String?) {
+        this.revealRiskId = revealRiskId
+    }
+
+    fun getRevealRiskId(): String? = revealRiskId
+
+    fun clearRevealRiskId() {
+        this.revealRiskId = null
+    }
+
     fun revealRisk(
         callback: (
             status: RadarStatus,
@@ -19,9 +31,15 @@ internal class RadarRevealRiskManager(
                 callback(status, null)
                 return@getFraudPayload
             }
+
             Radar.apiClient.revealRisk(
                 fraudPayload,
-                callback = callback
+                callback = { status, token ->
+                    run {
+                        setRevealRiskId(token?.id)
+                        callback(status, token)
+                    }
+                }
             )
         }
     }

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -25,7 +25,8 @@ import org.json.JSONObject
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal class RadarVerificationManager(
     private val context: Context,
-    private val logger: RadarLogger
+    private val logger: RadarLogger,
+    private val revealRiskManager: RadarRevealRiskManager
 ) {
 
     var started = false
@@ -49,8 +50,6 @@ internal class RadarVerificationManager(
         desiredAccuracy: RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM,
         reason: String? = null,
         transactionId: String? = null,
-        revealRiskId: String? = null,
-        clearRevealRiskId: () -> Unit,
         callback: Radar.RadarTrackVerifiedCallback? = null
     ) {
         val verificationManager = this
@@ -113,7 +112,7 @@ internal class RadarVerificationManager(
                                         verificationManager.expectedStateCode,
                                         reason ?: "manual",
                                         transactionId,
-                                        revealRiskId,
+                                        revealRiskManager.getRevealRiskId(),
                                         fraudPayload,
                                         callback = object : RadarApiClient.RadarTrackApiCallback {
                                             override fun onComplete(
@@ -126,7 +125,8 @@ internal class RadarVerificationManager(
                                                 token: RadarVerifiedLocationToken?
                                             ) {
                                                 if (status == Radar.RadarStatus.SUCCESS) {
-                                                    clearRevealRiskId()
+                                                    revealRiskManager.clearRevealRiskId()
+
                                                     Radar.locationManager.updateTrackingFromMeta(
                                                         config?.meta
                                                     )
@@ -274,15 +274,11 @@ internal class RadarVerificationManager(
             return
         }
 
-        val clearRevealRiskId: () -> Unit = { logger.e("Nothing to clear at this point") }
-
         verificationManager.trackVerified(
             this.startedBeacons,
             RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH,
             reason,
             null,
-            null,
-            clearRevealRiskId,
             object : Radar.RadarTrackVerifiedCallback {
                 override fun onComplete(
                     status: Radar.RadarStatus,
@@ -473,9 +469,7 @@ internal class RadarVerificationManager(
             return
         }
 
-        val clearRevealRiskId: () -> Unit = { logger.e("Nothing to clear at this point") }
-
-        this.trackVerified(beacons, desiredAccuracy, "last_token_invalid", null, null, clearRevealRiskId, callback)
+        this.trackVerified(beacons, desiredAccuracy, "last_token_invalid", null, callback)
     }
 
     fun clearVerifiedLocationToken() {

--- a/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
+++ b/sdk/src/main/java/io/radar/sdk/RadarVerificationManager.kt
@@ -49,6 +49,8 @@ internal class RadarVerificationManager(
         desiredAccuracy: RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy = RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.MEDIUM,
         reason: String? = null,
         transactionId: String? = null,
+        revealRiskId: String? = null,
+        clearRevealRiskId: () -> Unit,
         callback: Radar.RadarTrackVerifiedCallback? = null
     ) {
         val verificationManager = this
@@ -111,6 +113,7 @@ internal class RadarVerificationManager(
                                         verificationManager.expectedStateCode,
                                         reason ?: "manual",
                                         transactionId,
+                                        revealRiskId,
                                         fraudPayload,
                                         callback = object : RadarApiClient.RadarTrackApiCallback {
                                             override fun onComplete(
@@ -123,6 +126,7 @@ internal class RadarVerificationManager(
                                                 token: RadarVerifiedLocationToken?
                                             ) {
                                                 if (status == Radar.RadarStatus.SUCCESS) {
+                                                    clearRevealRiskId()
                                                     Radar.locationManager.updateTrackingFromMeta(
                                                         config?.meta
                                                     )
@@ -270,11 +274,15 @@ internal class RadarVerificationManager(
             return
         }
 
+        val clearRevealRiskId: () -> Unit = { logger.e("Nothing to clear at this point") }
+
         verificationManager.trackVerified(
             this.startedBeacons,
             RadarTrackingOptions.RadarTrackingOptionsDesiredAccuracy.HIGH,
             reason,
             null,
+            null,
+            clearRevealRiskId,
             object : Radar.RadarTrackVerifiedCallback {
                 override fun onComplete(
                     status: Radar.RadarStatus,
@@ -465,7 +473,9 @@ internal class RadarVerificationManager(
             return
         }
 
-        this.trackVerified(beacons, desiredAccuracy, "last_token_invalid", null, callback)
+        val clearRevealRiskId: () -> Unit = { logger.e("Nothing to clear at this point") }
+
+        this.trackVerified(beacons, desiredAccuracy, "last_token_invalid", null, null, clearRevealRiskId, callback)
     }
 
     fun clearVerifiedLocationToken() {


### PR DESCRIPTION
<!--
Thanks for contributing to the Radar Android SDK! 💙

External contributors: a Radar team member will review your PR. By contributing you
agree your changes are licensed under this repo's Apache 2.0 license. No CLA needed.

Before opening, please run the same checks CI runs:
  ./gradlew :sdk:ktlintCheck
  ./gradlew :sdk:lintDebug
  ./gradlew test
-->

## Summary

Added the reveal risk id to the track verified call, if present, and not in the fraud payload.

## Linear ticket (Radar internal)

FRA-2137

## Related issue

https://github.com/radarlabs/server/pull/8170

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (alters existing public API behavior)
- [ ] Documentation / internal only (no SDK behavior change)

## Manual test steps

<!--
How did you verify this? Give steps a reviewer can follow when possible — ideally
via the example app in `example/`. Include device/OS/emulator and any setup.
-->

1. Open example application
2. Run RevealRisk endpoint
3. Run Track Verified endpoint
4. check the location information for the track verified, revealRiskID is in the body
5. Run Track Verified a second time
6. Ncheck the new location information, there will be no revealRiskId in the body

## Checklist

- [ ] Added or updated unit tests (`./gradlew test`)
- [x] `./gradlew :sdk:ktlintCheck` and `./gradlew :sdk:lintDebug` pass locally
- [x] For breaking changes: added a `MIGRATION.md` entry and bumped `version` in `sdk/build.gradle`
- [x] Updated README / public docs if the public API changed
- [x] No real API keys committed in the example app
- [ x Only fixed lint/ktlint violations on lines I changed; removed any now-stale baseline entries

## Screenshots / recordings (optional)
<img width="495" height="226" alt="Screenshot 2026-08-11 at 9 59 06 AM" src="https://github.com/user-attachments/assets/fbada8aa-2a12-4b45-ba26-cf8294b71e68" />

